### PR TITLE
Remove folder icon from page list and use native update dialogs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef, type ReactNode } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useFrameStore, isRootId } from './store/frameStore'
 import { TreePanel } from './components/TreePanel/TreePanel'
 import { Canvas } from './components/Canvas/Canvas'
@@ -15,8 +15,7 @@ import { startMcpBridge, stopMcpBridge } from './mcp/bridge'
 import { TitleBar } from './components/TitleBar/TitleBar'
 import { ZOOM_LEVELS } from './components/Canvas/ZoomBar'
 import { switchTheme, getActiveTheme } from './lib/theme'
-import { checkForUpdates, relaunchApp, type UpdateStatus } from './lib/updater'
-import * as Dialog from '@radix-ui/react-dialog'
+import { checkForUpdates } from './lib/updater'
 
 const LEFT_MIN = 150
 const LEFT_MAX = 400
@@ -57,8 +56,6 @@ function safeMenuSync(invoke: (cmd: string, args?: Record<string, unknown>) => P
 function App() {
   const [showExport, setShowExport] = useState(false)
   const [showExportLibrary, setShowExportLibrary] = useState(false)
-  const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null)
-  const [showUpdater, setShowUpdater] = useState(false)
   const initial = useRef(loadPanelState())
   const [leftWidth, setLeftWidth] = useState(initial.current.leftWidth)
   const [rightWidth, setRightWidth] = useState(initial.current.rightWidth)
@@ -209,8 +206,7 @@ function App() {
             setShowExport(true)
             break
           case 'check-for-updates':
-            setShowUpdater(true)
-            checkForUpdates(setUpdateStatus)
+            checkForUpdates()
             break
           case 'save-library': {
             const lastExport = useCatalogStore.getState().lastExport
@@ -464,61 +460,8 @@ function App() {
         <ExportModal open={showExport} onOpenChange={setShowExport} />
         <ExportLibraryModal open={showExportLibrary} onOpenChange={setShowExportLibrary} />
 
-        {/* Updater dialog */}
-        <UpdateDialog
-          open={showUpdater}
-          onOpenChange={(open) => { setShowUpdater(open); if (!open) setUpdateStatus(null) }}
-          status={updateStatus}
-        />
       </div>
     </TooltipProvider>
-  )
-}
-
-function UpdateDialog({ open, onOpenChange, status }: { open: boolean; onOpenChange: (o: boolean) => void; status: UpdateStatus | null }) {
-  let content: ReactNode
-  if (!status || status.state === 'checking') {
-    content = <p className="text-text-secondary">Checking for updates...</p>
-  } else if (status.state === 'up-to-date') {
-    content = <p className="text-text-secondary">You're on the latest version.</p>
-  } else if (status.state === 'available') {
-    content = <p className="text-text-secondary">Downloading v{status.version}...</p>
-  } else if (status.state === 'downloading') {
-    const pct = Math.round(status.progress * 100)
-    content = (
-      <div className="flex flex-col gap-2">
-        <p className="text-text-secondary">Downloading... {pct}%</p>
-        <div className="h-1.5 bg-surface-2 rounded-full overflow-hidden">
-          <div className="h-full bg-accent rounded-full transition-all" style={{ width: `${pct}%` }} />
-        </div>
-      </div>
-    )
-  } else if (status.state === 'ready') {
-    content = (
-      <div className="flex flex-col gap-3">
-        <p className="text-text-secondary">Update downloaded. Restart to apply.</p>
-        <button
-          className="h-7 px-3 bg-accent text-white text-[12px] font-medium rounded hover:bg-accent-hover transition-colors"
-          onClick={() => relaunchApp()}
-        >
-          Restart Now
-        </button>
-      </div>
-    )
-  } else if (status.state === 'error') {
-    content = <p className="text-destructive text-[12px]">{status.message}</p>
-  }
-
-  return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-[320px] bg-surface-1 border border-border rounded-lg p-5 flex flex-col gap-3">
-          <Dialog.Title className="text-[13px] font-semibold text-text-primary">Check for Updates</Dialog.Title>
-          <div className="text-[12px]">{content}</div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
   )
 }
 

--- a/src/components/TreePanel/PageNode.tsx
+++ b/src/components/TreePanel/PageNode.tsx
@@ -2,7 +2,7 @@ import type { Page } from '../../types/frame'
 import { useFrameStore } from '../../store/frameStore'
 import { useContextMenu } from './hooks/useContextMenu'
 import { useInlineEdit } from './hooks/useInlineEdit'
-import { Folder, Check, Copy, Trash2 } from 'lucide-react'
+import { Check, Copy, Trash2 } from 'lucide-react'
 
 interface PageNodeProps {
   page: Page
@@ -35,8 +35,6 @@ export function PageNode({ page }: PageNodeProps) {
         onDoubleClick={() => nameEdit.start(page.name)}
         onContextMenu={ctxMenu.open}
       >
-        <Folder size={12} className="shrink-0" />
-
         {nameEdit.editing ? (
           <input {...nameEdit.inputProps} className="flex-1 h-5 bg-surface-2 border border-accent rounded px-1 text-[12px] font-semibold text-text-primary outline-none min-w-0" />
         ) : (

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,49 +1,40 @@
 import { check } from '@tauri-apps/plugin-updater'
 import { relaunch } from '@tauri-apps/plugin-process'
+import { ask, message } from '@tauri-apps/plugin-dialog'
 
-export type UpdateStatus =
-  | { state: 'checking' }
-  | { state: 'available'; version: string }
-  | { state: 'downloading'; progress: number }
-  | { state: 'ready' }
-  | { state: 'up-to-date' }
-  | { state: 'error'; message: string }
-
-export async function checkForUpdates(
-  onStatus: (status: UpdateStatus) => void,
-): Promise<void> {
+export async function checkForUpdates(): Promise<void> {
   try {
-    onStatus({ state: 'checking' })
     const update = await check()
 
     if (!update) {
-      onStatus({ state: 'up-to-date' })
+      await message("You're on the latest version.", {
+        title: 'Caja',
+        kind: 'info',
+      })
       return
     }
 
-    onStatus({ state: 'available', version: update.version })
+    const shouldUpdate = await ask(
+      `Version ${update.version} is available. Download and install?`,
+      { title: 'Update Available', kind: 'info', okLabel: 'Update', cancelLabel: 'Later' },
+    )
 
-    let totalBytes = 0
-    let downloadedBytes = 0
+    if (!shouldUpdate) return
 
-    await update.downloadAndInstall((event) => {
-      if (event.event === 'Started' && event.data.contentLength) {
-        totalBytes = event.data.contentLength
-      } else if (event.event === 'Progress') {
-        downloadedBytes += event.data.chunkLength
-        const progress = totalBytes > 0 ? downloadedBytes / totalBytes : 0
-        onStatus({ state: 'downloading', progress })
-      } else if (event.event === 'Finished') {
-        onStatus({ state: 'ready' })
-      }
-    })
+    await update.downloadAndInstall()
 
-    onStatus({ state: 'ready' })
+    const shouldRestart = await ask(
+      'Update installed. Restart now to apply?',
+      { title: 'Caja', kind: 'info', okLabel: 'Restart', cancelLabel: 'Later' },
+    )
+
+    if (shouldRestart) {
+      await relaunch()
+    }
   } catch (err) {
-    onStatus({ state: 'error', message: String(err) })
+    await message(`Failed to check for updates: ${err}`, {
+      title: 'Caja',
+      kind: 'info',
+    })
   }
-}
-
-export async function relaunchApp(): Promise<void> {
-  await relaunch()
 }


### PR DESCRIPTION
## Summary
- Remove Folder icon from page list items for cleaner UI
- Replace custom Radix Dialog updater with native macOS dialogs (ask/message)
- Simplify `checkForUpdates()` to three-step native flow: check → download → restart

## Test plan
- [ ] Page list shows page names without folder icons
- [ ] Caja > Check for Updates shows native macOS dialog
- [ ] Error state shows info dialog (not warning icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)