### PR TITLE
Add descriptive placeholders to property inputs

### DIFF
--- a/src/components/Properties/EffectsSection.tsx
+++ b/src/components/Properties/EffectsSection.tsx
@@ -40,6 +40,7 @@ export function EffectsSection({ frame }: { frame: Frame }) {
             inlineLabel={<Droplets size={12} />}
             classPrefix="blur"
             defaultValue={0}
+            placeholder="None"
           />
           <TokenInput
             scale={BLUR_SCALE}
@@ -49,6 +50,7 @@ export function EffectsSection({ frame }: { frame: Frame }) {
             inlineLabel={<Layers size={12} />}
             classPrefix="backdrop-blur"
             defaultValue={0}
+            placeholder="None"
           />
           <div className="w-5 shrink-0" />
         </div>

--- a/src/components/Properties/LayoutSection.tsx
+++ b/src/components/Properties/LayoutSection.tsx
@@ -274,6 +274,7 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
                         label="Col Span"
                         classPrefix="col-span"
                         defaultValue={0}
+                        placeholder="Auto"
                       />
                       <TokenInput
                         scale={ROW_SPAN_SCALE}
@@ -283,6 +284,7 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
                         label="Row Span"
                         classPrefix="row-span"
                         defaultValue={0}
+                        placeholder="Auto"
                       />
                     </>
                   )}
@@ -421,6 +423,7 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
                             label="Col Span"
                             classPrefix="col-span"
                             defaultValue={0}
+                            placeholder="Auto"
                           />
                           <TokenInput
                             scale={ROW_SPAN_SCALE}
@@ -430,6 +433,7 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
                             label="Row Span"
                             classPrefix="row-span"
                             defaultValue={0}
+                            placeholder="Auto"
                           />
                         </>
                       )}
@@ -453,6 +457,7 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
                     label="Columns"
                     classPrefix="grid-cols"
                     defaultValue={0}
+                    placeholder="Auto"
                   />
                   <TokenInput
                     scale={GRID_ROWS_SCALE}
@@ -462,6 +467,7 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
                     label="Rows"
                     classPrefix="grid-rows"
                     defaultValue={0}
+                    placeholder="Auto"
                   />
                   <div className="w-5 shrink-0" />
                 </div>

--- a/src/components/Properties/PositionSection.tsx
+++ b/src/components/Properties/PositionSection.tsx
@@ -148,6 +148,7 @@ export function PositionSection({ frame }: { frame: Frame }) {
                   label="Z-Index"
                   classPrefix="z"
                   defaultValue={0}
+                  placeholder="Auto"
                 />
                 <div className="w-5 shrink-0" />
               </div>

--- a/src/components/Properties/TransformSection.tsx
+++ b/src/components/Properties/TransformSection.tsx
@@ -18,6 +18,7 @@ export function TransformSection({ frame }: { frame: Frame }) {
             inlineLabel="R"
             classPrefix="rotate"
             defaultValue={0}
+            placeholder="0°"
           />
           <TokenInput
             scale={SCALE_SCALE}
@@ -27,6 +28,7 @@ export function TransformSection({ frame }: { frame: Frame }) {
             inlineLabel="S"
             classPrefix="scale"
             defaultValue={100}
+            placeholder="100%"
           />
           <div className="w-5 shrink-0" />
         </div>

--- a/src/components/Properties/TypographySection.tsx
+++ b/src/components/Properties/TypographySection.tsx
@@ -81,6 +81,7 @@ export function TypographySection({ frame }: { frame: TextStyles & { id: string 
             }}
             min={1}
             defaultValue={16}
+            placeholder="16"
             classPrefix="text"
             inlineLabel={lbl('S')}
           />


### PR DESCRIPTION
## Summary
- Add descriptive placeholder text to inputs that previously showed raw numbers or empty when at default
- Grid cols/rows + col/row span: "Auto" (0 = browser auto layout)
- Blur/backdrop blur: "None" (0 = no effect)
- Rotate: "0°", Scale: "100%" (with units for clarity)
- Font size: "16" (CSS initial)
- Z-index: "Auto" (CSS initial)

Placeholders display in muted text, distinguishing "not set" from explicit values.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 776/776 tests pass
- [ ] Visual: select a frame → verify placeholders show in muted text for unset properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)