### PR TITLE
Fix SpacingControl a.mode crash

### DIFF
--- a/src/components/ui/SpacingControl.tsx
+++ b/src/components/ui/SpacingControl.tsx
@@ -9,6 +9,7 @@ type SpacingMode = 'all' | 'axis' | 'sides'
 
 function dvSame(a: DesignValue<number> | undefined, b: DesignValue<number> | undefined): boolean {
   if (!a || !b) return a === b
+  if (!('mode' in a) || !('mode' in b)) return false
   return a.mode === b.mode && a.value === b.value && a.token === b.token
 }
 

--- a/src/store/frameFactories.ts
+++ b/src/store/frameFactories.ts
@@ -480,6 +480,19 @@ export function createSelect(overrides?: Partial<SelectElement>): SelectElement 
   }
 }
 
+/** Ensure a Spacing object has all 4 sides (fills missing sides with zero). */
+function ensureSpacing(s: unknown): Spacing | undefined {
+  if (!s || typeof s !== 'object') return undefined
+  const r = s as Record<string, unknown>
+  const zero: DesignValue<number> = { mode: 'custom', value: 0 }
+  return {
+    top: (r.top && typeof r.top === 'object' && 'mode' in r.top) ? r.top as DesignValue<number> : zero,
+    right: (r.right && typeof r.right === 'object' && 'mode' in r.right) ? r.right as DesignValue<number> : zero,
+    bottom: (r.bottom && typeof r.bottom === 'object' && 'mode' in r.bottom) ? r.bottom as DesignValue<number> : zero,
+    left: (r.left && typeof r.left === 'object' && 'mode' in r.left) ? r.left as DesignValue<number> : zero,
+  }
+}
+
 /** Normalize a potentially incomplete frame (e.g. from external JSON) by filling in
  *  missing fields with defaults based on its type. Recurses into children. */
 export function normalizeFrame(frame: Frame): Frame {
@@ -488,11 +501,15 @@ export function normalizeFrame(frame: Frame): Frame {
     input: createInput, textarea: createTextarea, select: createSelect, link: createLink,
   }
   const create = creators[frame.type] || creators.text
-  // Migrate old border format (pattern data / .caja files may have { width } instead of { top/right/bottom/left })
   const migrated: Record<string, unknown> = { ...frame }
+  // Migrate old border format (pattern data / .caja files may have { width } instead of { top/right/bottom/left })
   if (migrated.border && typeof migrated.border === 'object') {
     migrated.border = migrateBorder(migrated.border)
   }
+  // Ensure spacing objects have all 4 sides (prevents dvSame crash)
+  if (migrated.padding) migrated.padding = ensureSpacing(migrated.padding)
+  if (migrated.margin) migrated.margin = ensureSpacing(migrated.margin)
+  if (migrated.inset) migrated.inset = ensureSpacing(migrated.inset)
   if (frame.type === 'box') {
     const children = (frame as BoxElement).children?.map(normalizeFrame) || []
     return create({ ...migrated, children } as Partial<any>)

--- a/src/store/frameStore.ts
+++ b/src/store/frameStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { Frame, BoxElement, TextElement, ImageElement, ButtonElement, InputElement, TextareaElement, SelectElement, Spacing, SizeValue, BorderRadius, Page } from '../types/frame'
+import type { Frame, BoxElement, TextElement, ImageElement, ButtonElement, InputElement, TextareaElement, SelectElement, DesignValue, Spacing, SizeValue, BorderRadius, Page } from '../types/frame'
 import { useCatalogStore } from './catalogStore'
 import {
   createBox, createText, createImage, createButton, createInput,
@@ -641,7 +641,12 @@ export const useFrameStore = create<FrameStore>((set, get) => ({
   updateSpacing: (id, field, values) =>
     set((state) => {
       const history = pushHistory(state)
-      const newRoot = updateInTree(state.root, id, (f) => ({ ...f, [field]: { ...f[field], ...values } })) as BoxElement
+      const ZERO: DesignValue<number> = { mode: 'custom', value: 0 }
+      const existing = (f: Frame) => {
+        const s = f[field] as Spacing | undefined
+        return { top: s?.top ?? ZERO, right: s?.right ?? ZERO, bottom: s?.bottom ?? ZERO, left: s?.left ?? ZERO }
+      }
+      const newRoot = updateInTree(state.root, id, (f) => ({ ...f, [field]: { ...existing(f), ...values } })) as BoxElement
       return { ...updateActiveRoot(state, newRoot), ...history }
     }),
 


### PR DESCRIPTION
## Summary
Fixes the known `TypeError: undefined is not an object (evaluating 'a.mode')` crash in SpacingControl.

**Root cause**: `updateSpacing()` does `{ ...f[field], ...values }` — if the existing spacing object is already partial (missing sides), the merge propagates the gaps. When SpacingControl's `dvSame()` later accesses `.mode` on a missing side, it crashes.

**Three-layer fix**:
- `updateSpacing()`: backfill all 4 sides with zero before merging partial updates
- `dvSame()`: guard against malformed objects missing `mode` property
- `normalizeFrame()`: validate all Spacing objects (padding/margin/inset) have 4 sides

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 776/776 tests pass
- [ ] Manual: rapid padding/margin edits, undo/redo spacing changes, paste frames across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)