### PR TITLE
Add panel toggle shortcuts and remove dead overlay code

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -372,11 +372,13 @@ pub fn run() {
                 .select_all()
                 .build()?;
 
-            let spacing_overlays_item = CheckMenuItemBuilder::with_id("toggle-spacing-overlays", "Spacing Overlays")
-                .accelerator("CmdOrCtrl+Shift+O")
+            let toggle_left_panel = CheckMenuItemBuilder::with_id("toggle-left-panel", "Left Panel")
+                .checked(true)
+                .accelerator("CmdOrCtrl+\\")
                 .build(app)?;
-            let overlay_values_item = CheckMenuItemBuilder::with_id("toggle-overlay-values", "Overlay Values")
-                .accelerator("CmdOrCtrl+Shift+V")
+            let toggle_right_panel = CheckMenuItemBuilder::with_id("toggle-right-panel", "Right Panel")
+                .checked(true)
+                .accelerator("CmdOrCtrl+Shift+\\")
                 .build(app)?;
 
             let advanced_mode_item = CheckMenuItemBuilder::with_id("toggle-advanced-mode", "Advanced Mode")
@@ -398,8 +400,8 @@ pub fn run() {
                 .build()?;
 
             let view_menu = SubmenuBuilder::new(app, "View")
-                .item(&spacing_overlays_item)
-                .item(&overlay_values_item)
+                .item(&toggle_left_panel)
+                .item(&toggle_right_panel)
                 .separator()
                 .item(&advanced_mode_item)
                 .separator()
@@ -525,7 +527,7 @@ pub fn run() {
 
             // For check menu items, emit their new checked state
             match id {
-                "toggle-spacing-overlays" | "toggle-overlay-values" | "toggle-advanced-mode" => {
+                "toggle-left-panel" | "toggle-right-panel" | "toggle-advanced-mode" => {
                     use tauri::menu::MenuItemKind;
                     if let Some(menu) = app.menu() {
                         for item in menu.items().unwrap_or_default() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,8 @@ function App() {
   const initial = useRef(loadPanelState())
   const [leftWidth, setLeftWidth] = useState(initial.current.leftWidth)
   const [rightWidth, setRightWidth] = useState(initial.current.rightWidth)
+  const [leftCollapsed, setLeftCollapsed] = useState(false)
+  const [rightCollapsed, setRightCollapsed] = useState(false)
 
   // Persist panel state on change
   useEffect(() => {
@@ -164,9 +166,9 @@ function App() {
     // Sync initial view prefs to native menu check states
     if (isTauri) {
       import('@tauri-apps/api/core').then(({ invoke }) => {
-        const { showSpacingOverlays, showOverlayValues, advancedMode } = useFrameStore.getState()
-        safeMenuSync(invoke, 'toggle-spacing-overlays', showSpacingOverlays)
-        safeMenuSync(invoke, 'toggle-overlay-values', showOverlayValues)
+        const { advancedMode } = useFrameStore.getState()
+        safeMenuSync(invoke, 'toggle-left-panel', true)
+        safeMenuSync(invoke, 'toggle-right-panel', true)
         safeMenuSync(invoke, 'toggle-advanced-mode', advancedMode)
         // Sync theme radio checks
         const activeId = getActiveTheme().id
@@ -240,13 +242,12 @@ function App() {
       // Check menu events (View toggles) — payload is [id, checked]
       listen<[string, boolean]>('menu-check-event', (e) => {
         const [id, checked] = e.payload
-        const store = useFrameStore.getState()
-        if (id === 'toggle-spacing-overlays') {
-          store.setSpacingOverlays(checked)
-        } else if (id === 'toggle-overlay-values') {
-          store.setOverlayValues(checked)
+        if (id === 'toggle-left-panel') {
+          setLeftCollapsed(!checked)
+        } else if (id === 'toggle-right-panel') {
+          setRightCollapsed(!checked)
         } else if (id === 'toggle-advanced-mode') {
-          store.setAdvancedMode(checked)
+          useFrameStore.getState().setAdvancedMode(checked)
         }
       }).then((fn) => {
         if (active) unlisteners.push(fn); else fn()
@@ -338,22 +339,22 @@ function App() {
         e.preventDefault()
         handleOpen()
       }
-      // View toggles (keyboard shortcut — also sync native menu check state)
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'o') {
+      // Panel toggles
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === '\\') {
         e.preventDefault()
-        useFrameStore.getState().toggleSpacingOverlays()
-        if (isTauri) {
-          const checked = useFrameStore.getState().showSpacingOverlays
-          import('@tauri-apps/api/core').then(({ invoke }) => safeMenuSync(invoke, 'toggle-spacing-overlays', checked))
-        }
+        setLeftCollapsed((v) => {
+          const next = !v
+          if (isTauri) import('@tauri-apps/api/core').then(({ invoke }) => safeMenuSync(invoke, 'toggle-left-panel', !next))
+          return next
+        })
       }
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'v') {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === '\\') {
         e.preventDefault()
-        useFrameStore.getState().toggleOverlayValues()
-        if (isTauri) {
-          const checked = useFrameStore.getState().showOverlayValues
-          import('@tauri-apps/api/core').then(({ invoke }) => safeMenuSync(invoke, 'toggle-overlay-values', checked))
-        }
+        setRightCollapsed((v) => {
+          const next = !v
+          if (isTauri) import('@tauri-apps/api/core').then(({ invoke }) => safeMenuSync(invoke, 'toggle-right-panel', !next))
+          return next
+        })
       }
       // Advanced mode toggle
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'a') {
@@ -432,7 +433,7 @@ function App() {
         {/* Main panels */}
         <div className="flex-1 flex overflow-hidden">
           <WorkspaceDndProvider>
-            {!previewMode && (
+            {!previewMode && !leftCollapsed && (
               <div style={{ width: leftWidth }} className="shrink-0 border-r border-border relative">
                 <TreePanel onExportLibrary={() => setShowExportLibrary(true)} />
                 <div
@@ -444,7 +445,7 @@ function App() {
             <div className="flex-1 flex flex-col overflow-hidden">
               <Canvas />
             </div>
-            {!previewMode && (
+            {!previewMode && !rightCollapsed && (
               <div style={{ width: rightWidth }} className="shrink-0 border-l border-border relative">
                 <div
                   className="absolute top-0 -left-[3px] bottom-0 w-[7px] cursor-col-resize hover:bg-accent/40 transition-colors z-10"

--- a/src/store/frameStore.ts
+++ b/src/store/frameStore.ts
@@ -250,8 +250,6 @@ interface FrameStore {
   collapsedIds: Set<string>
   filePath: string | null
   dirty: boolean
-  showSpacingOverlays: boolean
-  showOverlayValues: boolean
   previewMode: boolean
   canvasWidth: number | null
   canvasZoom: number
@@ -309,10 +307,6 @@ interface FrameStore {
   loadFromFileMulti: (pages: Page[], activePageId: string, filePath: string) => void
   setFilePath: (path: string | null) => void
   markClean: () => void
-  toggleSpacingOverlays: () => void
-  toggleOverlayValues: () => void
-  setSpacingOverlays: (value: boolean) => void
-  setOverlayValues: (value: boolean) => void
   togglePreviewMode: () => void
   setPreviewMode: (value: boolean) => void
   setCanvasWidth: (width: number | null) => void
@@ -339,8 +333,6 @@ interface FrameStore {
 const VIEW_PREFS_KEY = 'caja-view-prefs'
 
 interface ViewPrefs {
-  showSpacingOverlays: boolean
-  showOverlayValues: boolean
   previewMode: boolean
   canvasWidth: number | null
   advancedMode: boolean
@@ -352,15 +344,13 @@ function loadViewPrefs(): ViewPrefs {
     if (raw) {
       const parsed = JSON.parse(raw)
       return {
-        showSpacingOverlays: parsed.showSpacingOverlays ?? true,
-        showOverlayValues: parsed.showOverlayValues ?? false,
         previewMode: parsed.previewMode ?? false,
         canvasWidth: parsed.canvasWidth ?? null,
         advancedMode: parsed.advancedMode ?? false,
       }
     }
   } catch (err) { console.warn('Failed to load view preferences:', err) }
-  return { showSpacingOverlays: true, showOverlayValues: false, previewMode: false, canvasWidth: null, advancedMode: false }
+  return { previewMode: false, canvasWidth: null, advancedMode: false }
 }
 
 function saveViewPrefs(prefs: ViewPrefs) {
@@ -406,8 +396,6 @@ export const useFrameStore = create<FrameStore>((set, get) => ({
   collapsedIds: new Set(),
   filePath: null,
   dirty: false,
-  showSpacingOverlays: initialViewPrefs.showSpacingOverlays,
-  showOverlayValues: initialViewPrefs.showOverlayValues,
   previewMode: initialViewPrefs.previewMode,
   canvasWidth: initialViewPrefs.canvasWidth,
   canvasZoom: 1,
@@ -814,35 +802,17 @@ export const useFrameStore = create<FrameStore>((set, get) => ({
 
   setFilePath: (path) => set({ filePath: path }),
   markClean: () => set({ dirty: false }),
-  toggleSpacingOverlays: () => set((s) => {
-    const next = !s.showSpacingOverlays
-    saveViewPrefs({ showSpacingOverlays: next, showOverlayValues: s.showOverlayValues, previewMode: s.previewMode, canvasWidth: s.canvasWidth, advancedMode: s.advancedMode })
-    return { showSpacingOverlays: next }
-  }),
-  toggleOverlayValues: () => set((s) => {
-    const next = !s.showOverlayValues
-    saveViewPrefs({ showSpacingOverlays: s.showSpacingOverlays, showOverlayValues: next, previewMode: s.previewMode, canvasWidth: s.canvasWidth, advancedMode: s.advancedMode })
-    return { showOverlayValues: next }
-  }),
-  setSpacingOverlays: (value) => set((s) => {
-    saveViewPrefs({ showSpacingOverlays: value, showOverlayValues: s.showOverlayValues, previewMode: s.previewMode, canvasWidth: s.canvasWidth, advancedMode: s.advancedMode })
-    return { showSpacingOverlays: value }
-  }),
-  setOverlayValues: (value) => set((s) => {
-    saveViewPrefs({ showSpacingOverlays: s.showSpacingOverlays, showOverlayValues: value, previewMode: s.previewMode, canvasWidth: s.canvasWidth, advancedMode: s.advancedMode })
-    return { showOverlayValues: value }
-  }),
   togglePreviewMode: () => set((s) => {
     const next = !s.previewMode
-    saveViewPrefs({ showSpacingOverlays: s.showSpacingOverlays, showOverlayValues: s.showOverlayValues, previewMode: next, canvasWidth: s.canvasWidth, advancedMode: s.advancedMode })
+    saveViewPrefs({ previewMode: next, canvasWidth: s.canvasWidth, advancedMode: s.advancedMode })
     return { previewMode: next, ...(next ? { selectedId: null, hoveredId: null } : {}) }
   }),
   setPreviewMode: (value) => set((s) => {
-    saveViewPrefs({ showSpacingOverlays: s.showSpacingOverlays, showOverlayValues: s.showOverlayValues, previewMode: value, canvasWidth: s.canvasWidth, advancedMode: s.advancedMode })
+    saveViewPrefs({ previewMode: value, canvasWidth: s.canvasWidth, advancedMode: s.advancedMode })
     return { previewMode: value, ...(value ? { selectedId: null, hoveredId: null } : {}) }
   }),
   setCanvasWidth: (width) => set((s) => {
-    saveViewPrefs({ showSpacingOverlays: s.showSpacingOverlays, showOverlayValues: s.showOverlayValues, previewMode: s.previewMode, canvasWidth: width, advancedMode: s.advancedMode })
+    saveViewPrefs({ previewMode: s.previewMode, canvasWidth: width, advancedMode: s.advancedMode })
     return { canvasWidth: width }
   }),
   setCanvasZoom: (zoom) => set({ canvasZoom: zoom }),
@@ -856,7 +826,7 @@ export const useFrameStore = create<FrameStore>((set, get) => ({
   setPatternDragFrame: (frame, origin) => set({ patternDragFrame: frame, patternDragOrigin: origin ?? null }),
   setTreePanelTab: (tab) => set({ treePanelTab: tab }),
   setAdvancedMode: (value) => set((s) => {
-    saveViewPrefs({ showSpacingOverlays: s.showSpacingOverlays, showOverlayValues: s.showOverlayValues, previewMode: s.previewMode, canvasWidth: s.canvasWidth, advancedMode: value })
+    saveViewPrefs({ previewMode: s.previewMode, canvasWidth: s.canvasWidth, advancedMode: value })
     return { advancedMode: value }
   }),
 


### PR DESCRIPTION
## Summary
- **Cmd+\** toggles left panel, **Cmd+Shift+\** toggles right panel (VSCode-style independent visibility)
- Native Tauri View menu updated with checkable "Left Panel" / "Right Panel" items replacing dead overlay toggles
- Removed all dead `showSpacingOverlays` / `showOverlayValues` state, actions, and ViewPrefs fields from the store (~27 lines deleted)

## Test plan
- [ ] Cmd+\ hides/shows left panel (tree/layers)
- [ ] Cmd+Shift+\ hides/shows right panel (properties)
- [ ] Native View menu checkmarks stay in sync with panel state
- [ ] Preview mode still hides both panels
- [ ] 776 tests pass, `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)