### PR TITLE
Add smart page-linking UX and button href support

### DIFF
--- a/src/components/Canvas/CanvasInline.tsx
+++ b/src/components/Canvas/CanvasInline.tsx
@@ -35,10 +35,12 @@ export function CanvasInline() {
     const href = anchor.getAttribute('href')
     if (!href) return
 
+    // Always prevent default — never let the browser navigate the editor window
+    e.preventDefault()
+
     const { pages, setActivePage } = useFrameStore.getState()
     const targetPage = pages.find((p) => p.route === href)
     if (targetPage) {
-      e.preventDefault()
       setActivePage(targetPage.id)
     }
   }, [])

--- a/src/components/Canvas/FrameRenderer.tsx
+++ b/src/components/Canvas/FrameRenderer.tsx
@@ -33,7 +33,7 @@ export function resolveTag(frame: Frame): keyof React.JSX.IntrinsicElements {
       return (tag === 'body' ? 'div' : tag) as keyof React.JSX.IntrinsicElements
     }
     case 'text': return (frame.tag || 'p') as keyof React.JSX.IntrinsicElements
-    case 'button': return 'button'
+    case 'button': return frame.href ? 'a' : 'button'
     case 'image': return frame.src ? 'img' : 'div'
     case 'input': return 'input'
     case 'textarea': return 'textarea'
@@ -251,9 +251,10 @@ export function FrameRenderer({ frame }: FrameRendererProps) {
         sel?.addRange(range)
         return
       }
-      if (e.metaKey && isText && frame.tag === 'a' && frame.href) {
+      const frameHref = (isText && frame.tag === 'a' && frame.href) || (isButton && frame.href)
+      if (e.metaKey && frameHref) {
         const { pages, setActivePage } = useFrameStore.getState()
-        const targetPage = pages.find((p) => p.route === frame.href)
+        const targetPage = pages.find((p) => p.route === frameHref)
         if (targetPage) {
           setActivePage(targetPage.id)
           return
@@ -339,7 +340,7 @@ export function FrameRenderer({ frame }: FrameRendererProps) {
       data-frame-id={frame.id}
       className={`${tailwind} ${stateClasses}`}
       {...editorHandlers}
-      {...(isText && frame.tag === 'a' && frame.href
+      {...(((isText && frame.tag === 'a') || (isButton && frame.href)) && frame.href
         ? previewMode
           ? { href: frame.href }
           : { 'data-navigable': true }

--- a/src/components/Properties/ElementSection.tsx
+++ b/src/components/Properties/ElementSection.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
-import { Eye, EyeOff, Plus, X, Check, Code } from 'lucide-react'
+import { Eye, EyeOff, Plus, X, Check, Code, Link } from 'lucide-react'
 import type { Frame, TextElement, ImageElement, ButtonElement, InputElement, TextareaElement, SelectElement, SelectOption } from '../../types/frame'
 import { useFrameStore } from '../../store/frameStore'
 import { TokenInput } from '../ui/TokenInput'
 import { ToggleGroup } from '../ui/ToggleGroup'
+import { Select } from '../ui/Select'
 import { TYPE_BADGE_STYLES, TYPE_BADGE_LABELS, getBadgeKey, BOX_TAG_OPTIONS, TEXT_TAG_OPTIONS, INPUT_TYPE_OPTIONS } from './constants'
 import { isExternalUrl, isLocalAssetPath, downloadAsset } from '../../lib/assetOps'
 
@@ -35,6 +36,51 @@ function Checkbox({ checked, onChange, label }: { checked: boolean; onChange: (v
       </span>
       <span className={`text-[12px] ${checked ? 'text-text-primary' : 'text-text-muted'}`}>{label}</span>
     </button>
+  )
+}
+
+function HrefPicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const pages = useFrameStore((s) => s.pages)
+
+  const matchedPage = value ? pages.find(p => p.route === value) : null
+  const isCustom = !!value && !matchedPage
+  const selectValue = !value ? '__none__' : matchedPage ? value : '__custom__'
+
+  const options = [
+    { value: '__none__', label: 'None' },
+    ...pages.map(p => ({ value: p.route, label: `${p.name} (${p.route})` })),
+    { value: '__custom__', label: 'URL' },
+  ]
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <span className="text-text-muted/50 shrink-0"><Link size={12} /></span>
+        <Select
+          value={selectValue}
+          options={options}
+          onChange={(v) => {
+            if (v === '__none__') onChange('')
+            else if (v === '__custom__') onChange(value || 'https://')
+            else onChange(v)
+          }}
+          className="flex-1"
+        />
+        <div className="w-5 shrink-0" />
+      </div>
+      {isCustom && (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="https://..."
+            className="flex-1 c-input"
+          />
+          <div className="w-5 shrink-0" />
+        </div>
+      )}
+    </>
   )
 }
 
@@ -137,16 +183,7 @@ export function ElementSection({ frame, isRoot }: { frame: Frame; isRoot: boolea
         return (
           <>
             {t.tag === 'a' && (
-              <div className="flex items-center gap-2">
-                <input
-                  type="text"
-                  value={t.href || ''}
-                  onChange={(e) => updateFrame(frame.id, { href: e.target.value })}
-                  placeholder="https://..."
-                  className="flex-1 c-input"
-                />
-                <div className="w-5 shrink-0" />
-              </div>
+              <HrefPicker value={t.href || ''} onChange={(v) => updateFrame(frame.id, { href: v })} />
             )}
             <div className="flex items-start gap-2">
               <textarea
@@ -233,16 +270,19 @@ export function ElementSection({ frame, isRoot }: { frame: Frame; isRoot: boolea
       {frame.type === 'button' && (() => {
         const btn = frame as ButtonElement
         return (
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              value={btn.content}
-              onChange={(e) => updateFrame(frame.id, { content: e.target.value })}
-              placeholder="Button text..."
-              className="flex-1 c-input"
-            />
-            <div className="w-5 shrink-0" />
-          </div>
+          <>
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={btn.content}
+                onChange={(e) => updateFrame(frame.id, { content: e.target.value })}
+                placeholder="Button text..."
+                className="flex-1 c-input"
+              />
+              <div className="w-5 shrink-0" />
+            </div>
+            <HrefPicker value={btn.href || ''} onChange={(v) => updateFrame(frame.id, { href: v })} />
+          </>
         )
       })()}
 

--- a/src/store/frameFactories.ts
+++ b/src/store/frameFactories.ts
@@ -321,6 +321,7 @@ export function createButton(overrides?: Partial<ButtonElement>): ButtonElement 
     className: '',
     htmlId: '',
     content: 'Button',
+    href: '',
     ...defaultTextStyles(),
     padding: zeroSpacing(),
     margin: zeroSpacing(),

--- a/src/types/frame.ts
+++ b/src/types/frame.ts
@@ -177,6 +177,7 @@ export interface ButtonElement extends BaseElement, TextStyles {
   type: 'button'
 
   content: string
+  href: string // when set, renders as <a> instead of <button>
 }
 
 export type InputType = 'text' | 'email' | 'password' | 'number' | 'search' | 'tel' | 'url' | 'date' | 'time' | 'checkbox' | 'radio' | 'range'

--- a/src/utils/exportHtml.ts
+++ b/src/utils/exportHtml.ts
@@ -44,6 +44,10 @@ export function exportToHTML(
   if (frame.type === 'button') {
     const content = escapeText(frame.content)
     const idAttr = resolveIdAttr(frame)
+    if (frame.href) {
+      const hrefAttr = ` href="${escapeAttr(frame.href)}"`
+      return `${pad}<a${idAttr}${hrefAttr}${classAttr}>${content}</a>\n`
+    }
     return `${pad}<button${idAttr} type="button"${classAttr}>${content}</button>\n`
   }
 

--- a/src/utils/exportTailwind.ts
+++ b/src/utils/exportTailwind.ts
@@ -40,6 +40,10 @@ export function exportToJSX(
   if (frame.type === 'button') {
     const content = escapeText(frame.content)
     const idAttr = resolveIdAttr(frame)
+    if (frame.href) {
+      const hrefAttr = ` href="${escapeAttr(frame.href)}"`
+      return `${pad}<a${idAttr}${hrefAttr} className="${classes}">${content}</a>\n`
+    }
     return `${pad}<button${idAttr} type="button" className="${classes}">${content}</button>\n`
   }
 


### PR DESCRIPTION
## Summary
- **HrefPicker component**: dropdown showing project pages by name/route + "URL" option for external links, replaces plain text input
- **Button href**: buttons can now link to pages or URLs — renders as `<a>` in canvas and exports
- **Navigation guardrail fix**: always `preventDefault` on link clicks in preview mode — prevents external URLs from hijacking the editor window
- **Cmd+Click** navigation extended to buttons with href

## Test plan
- [ ] Select a link element → HrefPicker shows pages dropdown + URL option
- [ ] Select a button → HrefPicker appears below content input
- [ ] Pick a page from dropdown → href set to page route
- [ ] Pick "URL" → text input appears for custom URL
- [ ] Pick "None" → href cleared
- [ ] Preview mode: click internal page link → navigates to page
- [ ] Preview mode: click external URL → does NOT navigate (stays in editor)
- [ ] Export HTML: button with href → renders as `<a href="...">`
- [ ] Cmd+Click on button with page href → navigates in editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)