### PR TITLE
Add light theme and system preference detection

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -385,18 +385,18 @@ pub fn run() {
                 .accelerator("CmdOrCtrl+Shift+A")
                 .build(app)?;
 
-            let theme_default = CheckMenuItemBuilder::with_id("theme-default-dark", "Default Dark")
+            let theme_system = CheckMenuItemBuilder::with_id("theme-system", "System")
                 .checked(true)
                 .build(app)?;
-            let theme_dracula = CheckMenuItemBuilder::with_id("theme-dracula", "Dracula")
+            let theme_dark = CheckMenuItemBuilder::with_id("theme-default-dark", "Dark")
                 .build(app)?;
-            let theme_catppuccin = CheckMenuItemBuilder::with_id("theme-catppuccin-mocha", "Catppuccin Mocha")
+            let theme_light = CheckMenuItemBuilder::with_id("theme-default-light", "Light")
                 .build(app)?;
 
             let themes_submenu = SubmenuBuilder::new(app, "Theme")
-                .item(&theme_default)
-                .item(&theme_dracula)
-                .item(&theme_catppuccin)
+                .item(&theme_system)
+                .item(&theme_dark)
+                .item(&theme_light)
                 .build()?;
 
             let view_menu = SubmenuBuilder::new(app, "View")
@@ -502,7 +502,7 @@ pub fn run() {
             let id = event.id().0.as_str();
 
             // Theme radio items — uncheck siblings, emit theme-change
-            let theme_ids = ["theme-default-dark", "theme-dracula", "theme-catppuccin-mocha"];
+            let theme_ids = ["theme-system", "theme-default-dark", "theme-default-light"];
             if theme_ids.contains(&id) {
                 use tauri::menu::MenuItemKind;
                 // Walk: menu > View submenu > Theme submenu > check items

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { WorkspaceDndProvider } from './components/TreePanel/WorkspaceDndContext
 import { startMcpBridge, stopMcpBridge } from './mcp/bridge'
 import { TitleBar } from './components/TitleBar/TitleBar'
 import { ZOOM_LEVELS } from './components/Canvas/ZoomBar'
-import { switchTheme, getActiveTheme } from './lib/theme'
+import { switchTheme, getThemePreference } from './lib/theme'
 import { checkForUpdates } from './lib/updater'
 
 const LEFT_MIN = 150
@@ -171,9 +171,9 @@ function App() {
         safeMenuSync(invoke, 'toggle-right-panel', true)
         safeMenuSync(invoke, 'toggle-advanced-mode', advancedMode)
         // Sync theme radio checks
-        const activeId = getActiveTheme().id
-        for (const tid of ['default-dark', 'dracula', 'catppuccin-mocha']) {
-          safeMenuSync(invoke, `theme-${tid}`, tid === activeId)
+        const pref = getThemePreference()
+        for (const tid of ['system', 'default-dark', 'default-light']) {
+          safeMenuSync(invoke, `theme-${tid}`, tid === pref)
         }
       }).catch((err) => console.warn('Failed to load Tauri core for menu sync:', err))
     }
@@ -255,6 +255,16 @@ function App() {
     })
     return () => { active = false; unlisteners.forEach((fn) => fn()) }
   }, [handleOpen, handleSave, handleSaveAs])
+
+  // Re-apply theme when system color scheme changes (only matters when preference is 'system')
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: light)')
+    const onChange = () => {
+      if (getThemePreference() === 'system') switchTheme('system')
+    }
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/src/lib/theme/__tests__/generate.test.ts
+++ b/src/lib/theme/__tests__/generate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { deriveTokens, generateThemeCSS } from '../generate'
 import { ThemeColor } from '../ThemeColor'
-import { DEFAULT_THEME } from '../types'
+import { DEFAULT_DARK } from '../types'
 
 /** Parse a CSS color and return RGB tuple */
 function rgb(css: string): [number, number, number] {
@@ -26,7 +26,7 @@ function expectColorMatch(actual: string, expected: string, tolerance = 1) {
 }
 
 describe('deriveTokens', () => {
-  const tokens = deriveTokens(DEFAULT_THEME)
+  const tokens = deriveTokens(DEFAULT_DARK)
 
   it('surface-0 matches input', () => {
     expectColorMatch(tokens['surface-0'], '#111111')
@@ -86,7 +86,7 @@ describe('deriveTokens', () => {
 })
 
 describe('generateThemeCSS', () => {
-  const css = generateThemeCSS(DEFAULT_THEME)
+  const css = generateThemeCSS(DEFAULT_DARK)
 
   it('wraps in :root {}', () => {
     expect(css).toMatch(/^:root \{/)

--- a/src/lib/theme/generate.ts
+++ b/src/lib/theme/generate.ts
@@ -1,6 +1,6 @@
 import { ThemeColor } from './ThemeColor'
 import type { CajaTheme } from './types'
-import { THEMES, DEFAULT_THEME } from './types'
+import { THEMES, DEFAULT_DARK, DEFAULT_LIGHT } from './types'
 
 const THEME_STORAGE_KEY = 'caja-theme-id'
 
@@ -25,20 +25,39 @@ export function deriveTokens(theme: CajaTheme): ThemeTokens {
   const text = ThemeColor.parse(theme.base.text)
   const accent = ThemeColor.parse(theme.base.accent)
 
+  if (theme.dark) {
+    return {
+      'surface-0': surface.css(),
+      'surface-1': surface.lift(0.042).css(),
+      'surface-2': surface.lift(0.088).css(),
+      'surface-3': surface.lift(0.193).css(),
+      'text-primary': text.css(),
+      'text-secondary': text.lower(0.329).css(),
+      'text-muted': text.lower(0.529).css(),
+      border: surface.lift(0.139).css(),
+      'border-accent': surface.lift(0.189).css(),
+      accent: accent.css(),
+      'accent-hover': accent.lift(0.066).css(),
+      destructive: ThemeColor.parse(theme.base.destructive).css(),
+      'canvas-bg': surface.lower(0.088).css(),
+    }
+  }
+
+  // Light mode — invert derivation direction
   return {
     'surface-0': surface.css(),
-    'surface-1': surface.lift(0.042).css(),
-    'surface-2': surface.lift(0.088).css(),
-    'surface-3': surface.lift(0.193).css(),
+    'surface-1': surface.lower(0.024).css(),
+    'surface-2': surface.lower(0.052).css(),
+    'surface-3': surface.lower(0.10).css(),
     'text-primary': text.css(),
-    'text-secondary': text.lower(0.329).css(),
-    'text-muted': text.lower(0.529).css(),
-    border: surface.lift(0.139).css(),
-    'border-accent': surface.lift(0.189).css(),
+    'text-secondary': text.lift(0.329).css(),
+    'text-muted': text.lift(0.529).css(),
+    border: surface.lower(0.10).css(),
+    'border-accent': surface.lower(0.15).css(),
     accent: accent.css(),
-    'accent-hover': accent.lift(0.066).css(),
+    'accent-hover': accent.lower(0.1).css(),
     destructive: ThemeColor.parse(theme.base.destructive).css(),
-    'canvas-bg': surface.lower(0.088).css(),
+    'canvas-bg': surface.lower(0.04).css(),
   }
 }
 
@@ -61,19 +80,37 @@ export function applyTheme(theme: CajaTheme, doc: Document = document): void {
   style.textContent = generateThemeCSS(theme)
 }
 
-/** Get the saved theme (falls back to DEFAULT_THEME) */
+/** Resolve system preference to a concrete theme */
+function resolveSystemTheme(): CajaTheme {
+  if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: light)').matches) {
+    return DEFAULT_LIGHT
+  }
+  return DEFAULT_DARK
+}
+
+/** Get the saved theme (falls back to system preference) */
 export function getActiveTheme(): CajaTheme {
   try {
     const id = localStorage.getItem(THEME_STORAGE_KEY)
-    if (id) return THEMES.find((t) => t.id === id) ?? DEFAULT_THEME
+    if (id === 'system') return resolveSystemTheme()
+    if (id) return THEMES.find((t) => t.id === id) ?? resolveSystemTheme()
   } catch { /* expected: SSR or iframe without localStorage access */ }
-  return DEFAULT_THEME
+  return resolveSystemTheme()
+}
+
+/** Get the stored preference ID ('system', 'default-dark', 'default-light') */
+export function getThemePreference(): string {
+  try {
+    return localStorage.getItem(THEME_STORAGE_KEY) || 'system'
+  } catch { return 'system' }
 }
 
 /** Persist theme choice and apply to the document */
 export function switchTheme(themeId: string, docs: Document[] = [document]): CajaTheme {
-  const theme = THEMES.find((t) => t.id === themeId) ?? DEFAULT_THEME
-  try { localStorage.setItem(THEME_STORAGE_KEY, theme.id) } catch { /* expected: SSR */ }
+  try { localStorage.setItem(THEME_STORAGE_KEY, themeId) } catch { /* expected: SSR */ }
+  const theme = themeId === 'system'
+    ? resolveSystemTheme()
+    : THEMES.find((t) => t.id === themeId) ?? resolveSystemTheme()
   for (const doc of docs) applyTheme(theme, doc)
   return theme
 }

--- a/src/lib/theme/index.ts
+++ b/src/lib/theme/index.ts
@@ -1,5 +1,5 @@
 export { ThemeColor } from './ThemeColor'
 export type { CajaTheme } from './types'
-export { DEFAULT_THEME, DRACULA_THEME, CATPPUCCIN_MOCHA_THEME, THEMES } from './types'
+export { DEFAULT_DARK, DEFAULT_LIGHT, THEMES } from './types'
 export type { ThemeTokens } from './generate'
-export { deriveTokens, generateThemeCSS, applyTheme, getActiveTheme, switchTheme } from './generate'
+export { deriveTokens, generateThemeCSS, applyTheme, getActiveTheme, getThemePreference, switchTheme } from './generate'

--- a/src/lib/theme/types.ts
+++ b/src/lib/theme/types.ts
@@ -10,9 +10,9 @@ export interface CajaTheme {
   }
 }
 
-export const DEFAULT_THEME: CajaTheme = {
+export const DEFAULT_DARK: CajaTheme = {
   id: 'default-dark',
-  label: 'Default Dark',
+  label: 'Dark',
   dark: true,
   base: {
     surface: '#111111',
@@ -22,28 +22,16 @@ export const DEFAULT_THEME: CajaTheme = {
   },
 }
 
-export const DRACULA_THEME: CajaTheme = {
-  id: 'dracula',
-  label: 'Dracula',
-  dark: true,
+export const DEFAULT_LIGHT: CajaTheme = {
+  id: 'default-light',
+  label: 'Light',
+  dark: false,
   base: {
-    surface: '#282a36',
-    text: '#f8f8f2',
-    accent: '#bd93f9',
-    destructive: '#ff5555',
+    surface: '#ffffff',
+    text: '#1a1a1a',
+    accent: '#0c8ce9',
+    destructive: '#ef4444',
   },
 }
 
-export const CATPPUCCIN_MOCHA_THEME: CajaTheme = {
-  id: 'catppuccin-mocha',
-  label: 'Catppuccin Mocha',
-  dark: true,
-  base: {
-    surface: '#1e1e2e',
-    text: '#cdd6f4',
-    accent: '#89b4fa',
-    destructive: '#f38ba8',
-  },
-}
-
-export const THEMES: CajaTheme[] = [DEFAULT_THEME, DRACULA_THEME, CATPPUCCIN_MOCHA_THEME]
+export const THEMES: CajaTheme[] = [DEFAULT_DARK, DEFAULT_LIGHT]


### PR DESCRIPTION
## Summary
- **System/Dark/Light** replaces Dracula/Catppuccin in View > Theme menu
- System default: follows macOS appearance via `prefers-color-scheme`
- Light mode: inverted HSL derivation from same base color system
- Auto-switches when OS appearance changes (only when preference is "System")

## Test plan
- [ ] View > Theme > System → follows macOS light/dark
- [ ] View > Theme > Dark → always dark
- [ ] View > Theme > Light → always light
- [ ] Toggle macOS appearance while on "System" → theme updates live
- [ ] Preference persists across app restart
- [ ] Menu radio checks stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)