### PR TITLE
Polish alignment grid with 3-line Figma-style cells

### DIFF
--- a/src/components/Properties/LayoutSection.tsx
+++ b/src/components/Properties/LayoutSection.tsx
@@ -314,7 +314,13 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
                       const active = isSpaceBetween
                         ? currentA === a
                         : currentJ === j && currentA === a
-                      const lineSz = isRow ? 'w-[2px] h-[7px]' : 'w-[7px] h-[2px]'
+                      const jCls = { start: 'justify-start', center: 'justify-center', end: 'justify-end' }[j]
+                      const aCls = { start: 'items-start', center: 'items-center', end: 'items-end' }[a]
+                      const justifyCls = active && isSpaceBetween ? 'justify-between' : jCls
+                      const lineSz = active
+                        ? (isRow ? 'w-[1.5px] h-[6px]' : 'w-[6px] h-[1.5px]')
+                        : (isRow ? 'w-[1px] h-[4px]' : 'w-[4px] h-[1px]')
+                      const lineColor = active ? 'bg-accent' : 'bg-text-muted/25'
                       return (
                         <button
                           key={`${ri}-${ci}`}
@@ -324,20 +330,10 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
                             else updateFrame(frame.id, { justify: j, align: a })
                           }}
                         >
-                          <div className="w-full h-full flex items-center justify-center">
-                            {active ? (
-                              isSpaceBetween ? (
-                                <div className={`${lineSz} bg-accent rounded-full`} />
-                              ) : (
-                                <div className={`w-[14px] h-[14px] flex ${isRow ? 'flex-row' : 'flex-col'} ${{ start: 'justify-start', center: 'justify-center', end: 'justify-end' }[j]} ${{ start: 'items-start', center: 'items-center', end: 'items-end' }[a]} gap-[1px] p-[1.5px]`}>
-                                  <div className={`${lineSz} bg-accent rounded-full`} />
-                                  <div className={`${lineSz} bg-accent rounded-full`} />
-                                  <div className={`${lineSz} bg-accent rounded-full`} />
-                                </div>
-                              )
-                            ) : (
-                              <div className="w-[3px] h-[3px] rounded-full bg-surface-3" />
-                            )}
+                          <div className={`w-full h-full flex ${isRow ? 'flex-row' : 'flex-col'} ${justifyCls} ${aCls} gap-[1px] p-[2px]`}>
+                            <div className={`${lineSz} ${lineColor} rounded-full`} />
+                            <div className={`${lineSz} ${lineColor} rounded-full`} />
+                            <div className={`${lineSz} ${lineColor} rounded-full`} />
                           </div>
                         </button>
                       )


### PR DESCRIPTION
## Summary
- All 9 cells now render 3 small lines positioned to visualize justify+align
- Active cell: accent-colored, larger lines (`1.5px × 6px`)
- Inactive cells: muted smaller lines (`1px × 4px`)
- Space-between: active cell uses `justify-between` to spread lines

## Test plan
- [ ] Select a flex container → all 9 cells show 3 lines
- [ ] Click cells → justify/align updates, active cell highlights in accent
- [ ] Toggle direction (row ↔ column) → lines rotate orientation
- [ ] Enable space-between → active cell lines spread apart

🤖 Generated with [Claude Code](https://claude.com/claude-code)