### PR TITLE
Reserve component fields in Frame type for v0.2

### DIFF
--- a/src/types/frame.ts
+++ b/src/types/frame.ts
@@ -107,6 +107,11 @@ interface BaseElement {
 
   // Origin tracking — populated when inserting from a pattern source (passive, informational)
   _origin?: { libraryId?: string; patternId?: string }
+
+  // Reserved for v0.2 component system — not used in 0.1.
+  // Ensures patterns/libraries created in 0.1 are forward-compatible.
+  _componentId?: string                        // ID of the component definition this frame is an instance of
+  _componentProps?: Record<string, unknown>     // Override props for the component instance
 }
 
 export type BoxTag = 'body' | 'div' | 'section' | 'nav' | 'header' | 'footer' | 'main' | 'article' | 'aside' | 'ul' | 'ol' | 'li' | 'form'


### PR DESCRIPTION
## Summary
- Add optional `_componentId` and `_componentProps` to `BaseElement`
- Not used in v0.1 — reserving for the v0.2 component system
- `JSON.stringify` already omits `undefined`, so zero impact on `.caja` / `.cjl` serialization
- Guarantees patterns and libraries created in 0.1 won't break when components ship

## Test plan
- [x] `tsc --noEmit` clean
- [x] 776 tests pass
- [ ] Save/open a .caja file → fields are not written (undefined omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)