### PR TITLE
Fix line-height showing 0 as active on new files

### DIFF
--- a/src/components/Properties/TypographySection.tsx
+++ b/src/components/Properties/TypographySection.tsx
@@ -100,6 +100,7 @@ export function TypographySection({ frame }: { frame: TextStyles & { id: string 
             value={frame.lineHeight}
             onChange={(v) => updateFrame(frame.id, { lineHeight: v })}
             min={0.5}
+            defaultValue={0}
             unit=""
             placeholder="Auto"
             classPrefix="leading"


### PR DESCRIPTION
## Summary
- lineHeight default is `dvNum(0)` (inherit) but TokenInput used `min` (0.5) as reset value
- Added `defaultValue={0}` so the field correctly shows "Auto" placeholder in muted text

🤖 Generated with [Claude Code](https://claude.com/claude-code)