### PR TITLE
Fix macOS title bar flickering during editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,23 +78,28 @@ function App() {
   const reorderFrame = useFrameStore((s) => s.reorderFrame)
   const selectedId = useFrameStore((s) => s.selectedId)
   const filePath = useFrameStore((s) => s.filePath)
-  const dirty = useFrameStore((s) => s.dirty)
   const previewMode = useFrameStore((s) => s.previewMode)
   const activePageId = useFrameStore((s) => s.activePageId)
   const pages = useFrameStore((s) => s.pages)
 
   // Update window title with file name + active page
+  // NOTE: dirty state is excluded — each setTitle() triggers a macOS traffic-light
+  // reposition (±1pt resize hack) which causes visible flicker when editing rapidly.
+  // The custom TitleBar already shows a dirty dot indicator.
+  const lastTitleRef = useRef('')
   useEffect(() => {
     if (!isTauri) return
     const fileName = filePath ? filePath.split('/').pop() : 'Untitled'
     const activePage = pages.find((p) => p.id === activePageId)
     const pageName = activePage?.name || ''
     const pageLabel = pages.length > 1 && pageName ? ` — ${pageName}` : ''
-    const title = dirty ? `${fileName}${pageLabel} — Edited · Caja` : `${fileName}${pageLabel} · Caja`
+    const title = `${fileName}${pageLabel} · Caja`
+    if (title === lastTitleRef.current) return
+    lastTitleRef.current = title
     import('@tauri-apps/api/core').then(({ invoke }) => {
       invoke('set_window_title', { title })
     }).catch((err) => console.warn('Failed to set window title:', err))
-  }, [filePath, dirty, activePageId, pages])
+  }, [filePath, activePageId, pages])
 
   const handleSave = useCallback(async () => {
     if (!isTauri) return


### PR DESCRIPTION
## Summary
- Remove `dirty` state from window title useEffect dependencies — each `setTitle()` triggers a ±1pt resize hack in Rust to reposition macOS traffic lights, causing visible flicker when editing rapidly
- Add `lastTitleRef` cache to skip redundant `invoke('set_window_title')` calls
- The custom TitleBar component already shows a dirty dot indicator, so the native title doesn't need the "Edited" suffix

## Test plan
- [ ] Edit properties rapidly (font size, colors, spacing) — traffic lights should stay still
- [ ] Switch pages, open/save files — title still updates correctly
- [ ] Verify dirty dot in TitleBar still appears on changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)