### PR TITLE
Add one-click MCP install for all clients

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,51 +216,46 @@ fn reposition_traffic_lights_after_title(ns_window: cocoa::base::id) {
     }
 }
 
-// Tauri command: install Caja MCP config into ~/.claude.json
-#[tauri::command]
-fn install_mcp_claude_code() -> Result<String, String> {
-    // 1. Resolve server.mjs path
-    let server_path = {
-        let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
-        let dev_path = cwd.join("../src/mcp/server.mjs");
-        if let Ok(canonical) = dev_path.canonicalize() {
-            canonical.to_string_lossy().to_string()
-        } else if let Ok(exe) = std::env::current_exe() {
-            if let Some(dir) = exe.parent() {
-                let path = dir.join("../Resources/src/mcp/server.mjs");
-                path.canonicalize()
-                    .map(|p| p.to_string_lossy().to_string())
-                    .map_err(|_| "Could not locate server.mjs".to_string())?
-            } else {
-                return Err("Could not locate server.mjs".into());
-            }
-        } else {
-            return Err("Could not locate server.mjs".into());
-        }
-    };
+// ── MCP Install Command ──
 
-    // 2. Read or create ~/.claude.json
-    let home = std::env::var("HOME").map_err(|_| "HOME not set".to_string())?;
-    let config_path = std::path::PathBuf::from(&home).join(".claude.json");
+fn resolve_server_path() -> Result<String, String> {
+    let cwd = std::env::current_dir().map_err(|e| e.to_string())?;
+    let dev_path = cwd.join("../src/mcp/server.mjs");
+    if let Ok(canonical) = dev_path.canonicalize() {
+        return Ok(canonical.to_string_lossy().to_string());
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let path = dir.join("../Resources/src/mcp/server.mjs");
+            if let Ok(canonical) = path.canonicalize() {
+                return Ok(canonical.to_string_lossy().to_string());
+            }
+        }
+    }
+    Err("Could not locate server.mjs".into())
+}
+
+/// Merge caja entry into a JSON config file.
+/// `servers_key` is the top-level key ("mcpServers" or "servers").
+fn install_json_config(config_path: &std::path::Path, servers_key: &str, server_path: &str) -> Result<String, String> {
+    // Ensure parent directory exists
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
 
     let mut config: serde_json::Value = if config_path.exists() {
-        let raw = std::fs::read_to_string(&config_path).map_err(|e| e.to_string())?;
+        let raw = std::fs::read_to_string(config_path).map_err(|e| e.to_string())?;
         serde_json::from_str(&raw).unwrap_or(serde_json::json!({}))
     } else {
         serde_json::json!({})
     };
 
-    // 3. Check if already configured
-    if config.get("mcpServers")
-        .and_then(|s| s.get("caja"))
-        .is_some()
-    {
+    if config.get(servers_key).and_then(|s| s.get("caja")).is_some() {
         return Ok("already".into());
     }
 
-    // 4. Merge caja server config
     let servers = config.as_object_mut().unwrap()
-        .entry("mcpServers")
+        .entry(servers_key)
         .or_insert(serde_json::json!({}));
     servers.as_object_mut().unwrap().insert(
         "caja".into(),
@@ -270,11 +265,79 @@ fn install_mcp_claude_code() -> Result<String, String> {
         }),
     );
 
-    // 5. Write back
     let json = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
-    std::fs::write(&config_path, json).map_err(|e| e.to_string())?;
-
+    std::fs::write(config_path, json).map_err(|e| e.to_string())?;
     Ok("installed".into())
+}
+
+/// Append caja entry to Codex TOML config.
+fn install_codex_toml(config_path: &std::path::Path, server_path: &str) -> Result<String, String> {
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+
+    let content = if config_path.exists() {
+        std::fs::read_to_string(config_path).map_err(|e| e.to_string())?
+    } else {
+        String::new()
+    };
+
+    if content.contains("[mcp_servers.caja]") {
+        return Ok("already".into());
+    }
+
+    let block = format!(
+        "\n[mcp_servers.caja]\ncommand = \"node\"\nargs = [\"{}\"]\n",
+        server_path.replace('\\', "\\\\").replace('"', "\\\"")
+    );
+
+    let mut new_content = content;
+    if !new_content.is_empty() && !new_content.ends_with('\n') {
+        new_content.push('\n');
+    }
+    new_content.push_str(&block);
+
+    std::fs::write(config_path, new_content).map_err(|e| e.to_string())?;
+    Ok("installed".into())
+}
+
+#[tauri::command]
+fn resolve_mcp_server_path() -> Result<String, String> {
+    resolve_server_path()
+}
+
+#[tauri::command]
+fn install_mcp(client: String) -> Result<String, String> {
+    let server_path = resolve_server_path()?;
+    let home = std::env::var("HOME").map_err(|_| "HOME not set".to_string())?;
+    let home = std::path::PathBuf::from(&home);
+
+    match client.as_str() {
+        "claude-code" => {
+            install_json_config(&home.join(".claude.json"), "mcpServers", &server_path)
+        }
+        "claude-desktop" => {
+            install_json_config(
+                &home.join("Library/Application Support/Claude/claude_desktop_config.json"),
+                "mcpServers",
+                &server_path,
+            )
+        }
+        "cursor" => {
+            install_json_config(&home.join(".cursor/mcp.json"), "mcpServers", &server_path)
+        }
+        "vscode" => {
+            install_json_config(
+                &home.join("Library/Application Support/Code/User/mcp.json"),
+                "servers",
+                &server_path,
+            )
+        }
+        "codex" => {
+            install_codex_toml(&home.join(".codex/config.toml"), &server_path)
+        }
+        _ => Err(format!("Unknown client: {}", client)),
+    }
 }
 
 // Tauri command: set window title + reposition traffic lights (setTitle resets them)
@@ -302,7 +365,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
-        .invoke_handler(tauri::generate_handler![mcp_respond, set_menu_check, set_window_title, install_mcp_claude_code])
+        .invoke_handler(tauri::generate_handler![mcp_respond, set_menu_check, set_window_title, install_mcp, resolve_mcp_server_path])
         .setup(|app| {
             // ── Native Menu ──
             let icon = Image::from_bytes(include_bytes!("../icons/128x128@2x.png"))

--- a/src/components/McpModal/McpModal.tsx
+++ b/src/components/McpModal/McpModal.tsx
@@ -1,73 +1,37 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { Dialog } from '../ui/Dialog'
-import { useFrameStore } from '../../store/frameStore'
-import { Check, Copy, Plus } from 'lucide-react'
+import { Check, Copy, ChevronDown, ChevronRight } from 'lucide-react'
 
 interface McpModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
-type Client = 'claude-code' | 'claude-desktop' | 'codex' | 'vscode'
+type Client = 'claude-code' | 'claude-desktop' | 'cursor' | 'vscode' | 'codex'
+
+const isTauri = '__TAURI_INTERNALS__' in window
 
 const CLIENTS: { id: Client; label: string }[] = [
   { id: 'claude-code', label: 'Claude Code' },
   { id: 'claude-desktop', label: 'Claude Desktop' },
-  { id: 'codex', label: 'Codex' },
+  { id: 'cursor', label: 'Cursor' },
   { id: 'vscode', label: 'VS Code' },
+  { id: 'codex', label: 'Codex' },
 ]
 
-function getConfig(client: Client): { snippet: string; instructions: string } {
-  switch (client) {
-    case 'claude-code':
-      return {
-        snippet: JSON.stringify({
-          mcpServers: {
-            caja: {
-              command: 'node',
-              args: ['src/mcp/server.mjs'],
-            },
-          },
-        }, null, 2),
-        instructions: 'Add to .mcp.json in your project root.\nCaja must be running when the MCP server starts.',
-      }
-    case 'claude-desktop':
-      return {
-        snippet: JSON.stringify({
-          mcpServers: {
-            caja: {
-              command: 'node',
-              args: ['/absolute/path/to/caja/src/mcp/server.mjs'],
-            },
-          },
-        }, null, 2),
-        instructions: 'Merge into ~/Library/Application Support/Claude/claude_desktop_config.json\nReplace the path with the absolute path to server.mjs.\nTip: copy this config and ask your AI assistant to install it for you.',
-      }
-    case 'codex':
-      return {
-        snippet: JSON.stringify({
-          mcpServers: {
-            caja: {
-              command: 'node',
-              args: ['src/mcp/server.mjs'],
-            },
-          },
-        }, null, 2),
-        instructions: 'Add to .codex/mcp.json in your project root.\nCaja must be running when the MCP server starts.',
-      }
-    case 'vscode':
-      return {
-        snippet: JSON.stringify({
-          servers: {
-            caja: {
-              command: 'node',
-              args: ['src/mcp/server.mjs'],
-            },
-          },
-        }, null, 2),
-        instructions: 'Add to .vscode/mcp.json in your project root.\nCaja must be running when the MCP server starts.',
-      }
+function getSnippet(client: Client, serverPath: string): string {
+  if (client === 'codex') {
+    return `[mcp_servers.caja]\ncommand = "node"\nargs = ["${serverPath}"]`
   }
+  const key = client === 'vscode' ? 'servers' : 'mcpServers'
+  return JSON.stringify({
+    [key]: {
+      caja: {
+        command: 'node',
+        args: [serverPath],
+      },
+    },
+  }, null, 2)
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -90,10 +54,10 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-async function installClaudeCode(): Promise<'installed' | 'already' | 'error'> {
+async function installMcp(client: Client): Promise<'installed' | 'already' | 'error'> {
   try {
     const { invoke } = await import('@tauri-apps/api/core')
-    const result: string = await invoke('install_mcp_claude_code')
+    const result: string = await invoke('install_mcp', { client })
     return result as 'installed' | 'already'
   } catch (err) {
     console.error('Failed to install MCP config:', err)
@@ -102,35 +66,33 @@ async function installClaudeCode(): Promise<'installed' | 'already' | 'error'> {
 }
 
 export function McpModal({ open, onOpenChange }: McpModalProps) {
-  const mcpConnected = useFrameStore((s) => s.mcpConnected)
   const [activeClient, setActiveClient] = useState<Client>('claude-code')
   const [installState, setInstallState] = useState<'idle' | 'installed' | 'already' | 'error'>('idle')
+  const [showManual, setShowManual] = useState(false)
+  const [serverPath, setServerPath] = useState<string | null>(null)
 
-  const config = getConfig(activeClient)
+  // Resolve the real server.mjs path once
+  useEffect(() => {
+    if (!isTauri || !open) return
+    import('@tauri-apps/api/core').then(({ invoke }) =>
+      invoke<string>('resolve_mcp_server_path').then(setServerPath).catch(() => {}),
+    )
+  }, [open])
+
+  const config = getSnippet(activeClient, serverPath ?? '/path/to/caja/src/mcp/server.mjs')
 
   const handleInstall = useCallback(async () => {
-    const result = await installClaudeCode()
+    const result = await installMcp(activeClient)
     setInstallState(result)
     setTimeout(() => setInstallState('idle'), 3000)
-  }, [])
+  }, [activeClient])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <div className="bg-surface-1 border border-border rounded-xl w-[480px] max-h-[80vh] overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between px-5 pt-5 pb-3">
-          <div className="flex items-center gap-2.5">
-            <h2 className="text-[14px] font-semibold text-text-primary">MCP Server</h2>
-            <div className="flex items-center gap-1.5 text-[11px]">
-              <div
-                className={`w-1.5 h-1.5 rounded-full ${mcpConnected ? 'bg-accent' : 'bg-text-muted'}`}
-              />
-              <span className={mcpConnected ? 'text-accent' : 'text-text-muted'}>
-                {mcpConnected ? 'Running' : 'Offline'}
-              </span>
-            </div>
-          </div>
-          <span className="text-[11px] text-text-muted">localhost:3334</span>
+        <div className="px-5 pt-5 pb-3">
+          <h2 className="text-[14px] font-semibold text-text-primary">MCP Server</h2>
         </div>
 
         {/* Description */}
@@ -144,8 +106,8 @@ export function McpModal({ open, onOpenChange }: McpModalProps) {
           {CLIENTS.map((c) => (
             <button
               key={c.id}
-              onClick={() => setActiveClient(c.id)}
-              className={`px-3 py-1.5 rounded-md text-[12px] transition-colors ${
+              onClick={() => { setActiveClient(c.id); setInstallState('idle') }}
+              className={`px-2.5 py-1.5 rounded-md text-[12px] transition-colors ${
                 activeClient === c.id
                   ? 'bg-surface-3 text-text-primary'
                   : 'text-text-muted hover:text-text-secondary hover:bg-surface-2'
@@ -156,40 +118,48 @@ export function McpModal({ open, onOpenChange }: McpModalProps) {
           ))}
         </div>
 
-        {/* Config snippet */}
-        <div className="mx-5 mb-3 rounded-lg bg-surface-0 border border-border overflow-hidden">
-          <div className="flex items-center justify-between px-3 py-1.5 border-b border-border">
-            <span className="text-[11px] text-text-muted">Configuration</span>
-            <CopyButton text={config.snippet} />
-          </div>
-          <pre className="px-3 py-3 text-[11px] leading-relaxed text-text-secondary overflow-x-auto">
-            {config.snippet}
-          </pre>
-        </div>
-
-        {/* Install button (Claude Code only) */}
-        {activeClient === 'claude-code' && (
+        {/* Install button */}
+        {isTauri && (
           <div className="px-5 pb-3">
             <button
               onClick={handleInstall}
               disabled={installState !== 'idle'}
               className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-accent text-white text-[12px] font-medium hover:bg-accent-hover transition-colors disabled:opacity-60"
             >
-              {installState === 'idle' && <>Add to Claude Code</>}
-              {installState === 'installed' && <><Check size={14} /> Added to ~/.claude.json</>}
+              {installState === 'idle' && <>Add to {CLIENTS.find((c) => c.id === activeClient)!.label}</>}
+              {installState === 'installed' && <><Check size={14} /> Installed</>}
               {installState === 'already' && <><Check size={14} /> Already configured</>}
-              {installState === 'error' && <>Failed — copy config manually</>}
+              {installState === 'error' && <>Failed — try manual setup below</>}
             </button>
           </div>
         )}
 
-        {/* Instructions */}
+        {/* Manual setup (collapsible) */}
         <div className="px-5 pb-5">
-          <p className="text-[11px] text-text-muted leading-relaxed whitespace-pre-line">
-            {activeClient === 'claude-code'
-              ? 'Or copy the config above and add it manually.\nCaja must be running when Claude Code starts.'
-              : config.instructions}
-          </p>
+          <button
+            type="button"
+            onClick={() => setShowManual(!showManual)}
+            className="flex items-center gap-1 text-[11px] text-text-muted hover:text-text-secondary transition-colors mb-2"
+          >
+            {showManual ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
+            Manual setup
+          </button>
+          {showManual && (
+            <div className="rounded-lg bg-surface-0 border border-border overflow-hidden">
+              <div className="flex items-center justify-between px-3 py-1.5 border-b border-border">
+                <span className="text-[11px] text-text-muted">Configuration</span>
+                <CopyButton text={config} />
+              </div>
+              <pre className="px-3 py-3 text-[11px] leading-relaxed text-text-secondary overflow-x-auto">
+                {config}
+              </pre>
+            </div>
+          )}
+          {!showManual && (
+            <p className="text-[11px] text-text-muted leading-relaxed">
+              Caja must be running when the MCP client starts.
+            </p>
+          )}
         </div>
       </div>
     </Dialog>


### PR DESCRIPTION
## Summary
- Generic `install_mcp(client)` Rust command supports 5 clients: Claude Code, Claude Desktop, Cursor, VS Code (JSON configs), and Codex (TOML config)
- `resolve_mcp_server_path` command resolves the real absolute path to `server.mjs` so the manual config snippet shows the actual path, not a placeholder
- Simplified modal: removed `localhost:3334` display and status dot, collapsed config snippet under "Manual setup" toggle, install button is the primary CTA for all tabs

## Test plan
- [ ] Open MCP modal → 5 client tabs visible
- [ ] Click "Add to Claude Code" → writes to `~/.claude.json`
- [ ] Click "Add to Claude Desktop" → writes to `~/Library/Application Support/Claude/claude_desktop_config.json`
- [ ] Click "Add to Cursor" → writes to `~/.cursor/mcp.json`
- [ ] Click "Add to VS Code" → writes to `~/Library/Application Support/Code/User/mcp.json`
- [ ] Click "Add to Codex" → appends to `~/.codex/config.toml`
- [ ] Click again → shows "Already configured"
- [ ] Expand "Manual setup" → shows config with real resolved path
- [ ] Copy button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)