### PR TITLE
Align PagePanel with property section conventions

### DIFF
--- a/src/components/Properties/PagePanel.tsx
+++ b/src/components/Properties/PagePanel.tsx
@@ -1,3 +1,4 @@
+import { Type, Globe } from 'lucide-react'
 import { useFrameStore } from '../../store/frameStore'
 
 export function PagePanel() {
@@ -11,35 +12,47 @@ export function PagePanel() {
 
   return (
     <div className="h-full overflow-y-auto">
-      {/* Header */}
-      <div className="p-3 border-b border-border flex items-center gap-2">
-        <span className="text-[12px] px-1.5 py-0.5 rounded-md font-medium bg-accent/15 text-accent">
-          Page
-        </span>
-        <span className="text-[12px] text-text-primary font-semibold truncate">{page.name}</span>
-      </div>
-
-      {/* Fields */}
-      <div className="flex flex-col gap-3 px-3">
-        <div className="flex flex-col gap-1">
-          <span className="c-label">Name</span>
-          <input
-            type="text"
-            value={page.name}
-            onChange={(e) => renamePage(page.id, e.target.value)}
-            className="c-input"
-          />
+      <div className="p-3 border-b border-border flex flex-col gap-2">
+        {/* Header: badge */}
+        <div className="flex items-center gap-2">
+          <span className="text-[12px] px-1.5 py-0.5 rounded-md font-medium bg-accent/15 text-accent">
+            Page
+          </span>
+          <div className="flex-1" />
         </div>
 
-        <div className="flex flex-col gap-1">
-          <span className="c-label">Route</span>
-          <input
-            type="text"
-            value={page.route}
-            onChange={(e) => setPageRoute(page.id, e.target.value)}
-            className="c-input"
-            placeholder="/page-route"
-          />
+        {/* Name */}
+        <div className="flex items-center gap-2">
+          <div className="c-scale-input flex-1 flex items-center gap-0.5 overflow-hidden cursor-text">
+            <span title="Page Name" className="w-4 shrink-0 flex items-center justify-center text-text-muted">
+              <Type size={12} />
+            </span>
+            <input
+              type="text"
+              value={page.name}
+              onChange={(e) => renamePage(page.id, e.target.value)}
+              className="flex-1 min-w-0 text-[12px] text-text-primary"
+              placeholder="Page name"
+            />
+          </div>
+          <div className="w-5 shrink-0" />
+        </div>
+
+        {/* Route */}
+        <div className="flex items-center gap-2">
+          <div className="c-scale-input flex-1 flex items-center gap-0.5 overflow-hidden cursor-text">
+            <span title="Page Route" className="w-4 shrink-0 flex items-center justify-center text-text-muted">
+              <Globe size={12} />
+            </span>
+            <input
+              type="text"
+              value={page.route}
+              onChange={(e) => setPageRoute(page.id, e.target.value)}
+              className="flex-1 min-w-0 text-[12px] text-text-primary"
+              placeholder="/page-route"
+            />
+          </div>
+          <div className="w-5 shrink-0" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Use `c-scale-input` wrapper with inline icon labels (`Type` for name, `Globe` for route) matching TokenInput pattern
- Add `title` tooltips on all inline labels
- Match `gap-2`, `w-5` action slot, `border-b` pattern from ElementSection

## Test plan
- [ ] Deselect all frames → PagePanel shows with inline icons inside inputs
- [ ] Hover icons → tooltips "Page Name" and "Page Route" appear
- [ ] Edit name and route → works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)