### PR TITLE
Hide toolbar divider in preview mode

### DIFF
--- a/src/components/Canvas/Toolbar.tsx
+++ b/src/components/Canvas/Toolbar.tsx
@@ -194,7 +194,7 @@ export function Toolbar() {
         </div>
 
         {/* Section 3: Viewport (always visible) */}
-        <Divider />
+        {!previewMode && <Divider />}
         <div className="flex items-center gap-0.5 py-1 px-1">
           <DropdownButton
             icon={<CurrentIcon size={14} />}


### PR DESCRIPTION
## Summary
- Hide the separator between tools and viewport sections when preview mode collapses the tools

## Test plan
- [ ] Toggle preview mode — no orphan divider visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)