### PR TITLE
Add responsive overrides system with UX polish

### DIFF
--- a/src/components/Canvas/FrameRenderer.tsx
+++ b/src/components/Canvas/FrameRenderer.tsx
@@ -43,11 +43,13 @@ export function resolveTag(frame: Frame): keyof React.JSX.IntrinsicElements {
 }
 
 export function FrameRenderer({ frame: rawFrame }: FrameRendererProps) {
-  if (rawFrame.hidden) return null
+  const activeBreakpoint = useFrameStore((s) => s.activeBreakpoint)
+  const getEffectiveFrame = useFrameStore((s) => s.getEffectiveFrame)
 
-  // Instances are rendered directly from their stored tree (cloned from master at insert time).
-  // Override resolution via resolveInstance will be used later for master→instance propagation.
-  const frame = rawFrame
+  // Merge responsive overrides for the active breakpoint so the canvas
+  // renders the correct visual at each breakpoint without CSS container queries.
+  // Subscribing to activeBreakpoint ensures re-render when breakpoint changes.
+  const frame = activeBreakpoint === 'base' ? rawFrame : getEffectiveFrame(rawFrame)
 
   // Re-render when blob cache is updated (e.g. after restoreAllAssets on app load)
   useSyncExternalStore(subscribeAssets, getAssetSnapshot)
@@ -90,7 +92,9 @@ export function FrameRenderer({ frame: rawFrame }: FrameRendererProps) {
   const isEmpty = isBox && frame.children.length === 0 && !hasVisualPresence
   const isDragged = canvasDragId === frame.id
 
-  // Tailwind classes — container query prefixes for canvas rendering
+  // Tailwind classes — effective frame already has overrides merged,
+  // so base classes reflect the active breakpoint. toContainerQueries
+  // only needed for any user-added responsive classes in tailwindClasses.
   const tailwind = toContainerQueries(frameToClasses(frame))
 
   // In preview mode, infer cursor from semantic tag
@@ -263,6 +267,10 @@ export function FrameRenderer({ frame: rawFrame }: FrameRendererProps) {
     doc.addEventListener('keydown', onKeyDown)
     doc.addEventListener('keyup', onKeyUp)
   }, [frame.id])
+
+  // Hidden frames — checked after all hooks to comply with React rules.
+  // May change per breakpoint via getEffectiveFrame.
+  if (frame.hidden) return null
 
   // Editor event handlers
   const editorHandlers = !previewMode ? {

--- a/src/components/Canvas/Toolbar.tsx
+++ b/src/components/Canvas/Toolbar.tsx
@@ -1,18 +1,18 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useMemo } from 'react'
 import {
   Monitor, Tablet, Smartphone,
   Plus, MousePointer2, Type, Eye,
   Frame as FrameIcon, Link, ImageIcon, RectangleHorizontal, TextCursorInput, AlignLeft, ChevronDown,
 } from 'lucide-react'
 import { useFrameStore, isRootId } from '../../store/frameStore'
-import type { Frame } from '../../types/frame'
+import type { Frame, Breakpoint } from '../../types/frame'
 
 type ElementType = 'box' | 'text' | 'image' | 'button' | 'input' | 'textarea' | 'select' | 'link'
 
-const BREAKPOINTS = [
-  { label: 'Full', width: null as number | null, icon: Monitor },
-  { label: 'Tablet', width: 768, icon: Tablet },
-  { label: 'Mobile', width: 375, icon: Smartphone },
+const BREAKPOINTS: { label: string; width: number | null; icon: typeof Monitor; bp: Breakpoint }[] = [
+  { label: 'Full', width: null, icon: Monitor, bp: 'base' },
+  { label: 'Tablet', width: 767, icon: Tablet, bp: 'md' },
+  { label: 'Mobile', width: 375, icon: Smartphone, bp: 'sm' },
 ]
 
 const PRIMITIVES: { type: ElementType; icon: React.ReactNode; label: string }[] = [
@@ -98,9 +98,25 @@ export function Toolbar() {
   const setCanvasTool = useFrameStore((s) => s.setCanvasTool)
   const canvasWidth = useFrameStore((s) => s.canvasWidth)
   const setCanvasWidth = useFrameStore((s) => s.setCanvasWidth)
+  const activeBreakpoint = useFrameStore((s) => s.activeBreakpoint)
+  const setActiveBreakpoint = useFrameStore((s) => s.setActiveBreakpoint)
   const addChild = useFrameStore((s) => s.addChild)
   const getSelected = useFrameStore((s) => s.getSelected)
   const selectedId = useFrameStore((s) => s.selectedId)
+
+  const root = useFrameStore((s) => s.root)
+
+  // Count frames with overrides per breakpoint
+  const overrideCounts = useMemo(() => {
+    const counts: Record<string, number> = { md: 0, sm: 0 }
+    const walk = (f: Frame) => {
+      if (f.responsive?.md && Object.keys(f.responsive.md).length > 0) counts.md++
+      if (f.responsive?.sm && Object.keys(f.responsive.sm).length > 0) counts.sm++
+      if (f.type === 'box') f.children.forEach(walk)
+    }
+    walk(root)
+    return counts
+  }, [root])
 
   // Current responsive icon
   const currentBp = BREAKPOINTS.find((bp) => bp.width === canvasWidth) ?? BREAKPOINTS[0]
@@ -197,20 +213,29 @@ export function Toolbar() {
         {!previewMode && <Divider />}
         <div className="flex items-center gap-0.5 py-1 px-1">
           <DropdownButton
-            icon={<CurrentIcon size={14} />}
+            icon={<span className="relative">
+              <CurrentIcon size={14} />
+              {activeBreakpoint !== 'base' && (
+                <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-accent" />
+              )}
+            </span>}
             title={currentBp.label}
-            menu={BREAKPOINTS.map((bp) => {
-              const Icon = bp.icon
-              const active = bp.width === canvasWidth
+            menu={BREAKPOINTS.map((bpItem) => {
+              const Icon = bpItem.icon
+              const active = bpItem.width === canvasWidth
+              const hasOverrides = bpItem.bp !== 'base' && overrideCounts[bpItem.bp] > 0
               return (
                 <button
-                  key={bp.label}
+                  key={bpItem.label}
                   className={`c-menu-item ${active ? '!text-text-primary !bg-surface-3/60' : ''}`}
-                  onClick={() => setCanvasWidth(bp.width)}
+                  onClick={() => { setCanvasWidth(bpItem.width); setActiveBreakpoint(bpItem.bp) }}
                 >
-                  <Icon size={12} />
-                  {bp.label}
-                  {bp.width && <span className="ml-auto text-text-muted text-[10px]">{bp.width}px</span>}
+                  <span className="relative">
+                    <Icon size={12} />
+                    {hasOverrides && <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-accent" />}
+                  </span>
+                  {bpItem.label}
+                  {bpItem.width && <span className="ml-auto text-text-muted text-[10px]">{bpItem.width}px</span>}
                 </button>
               )
             })}

--- a/src/components/Properties/AppearanceSection.tsx
+++ b/src/components/Properties/AppearanceSection.tsx
@@ -6,12 +6,12 @@ import { TokenInput } from '../ui/TokenInput'
 import { BorderRadiusControl } from '../ui/BorderRadiusControl'
 import { OPACITY_SCALE } from '../../data/scales'
 
-export function AppearanceSection({ frame }: { frame: Frame }) {
+export function AppearanceSection({ frame, hasOverrides, onResetOverrides }: { frame: Frame; hasOverrides?: boolean; onResetOverrides?: () => void }) {
   const updateFrame = useFrameStore((s) => s.updateFrame)
   const updateBorderRadius = useFrameStore((s) => s.updateBorderRadius)
 
   return (
-    <Section title="Appearance">
+    <Section title="Appearance" hasOverrides={hasOverrides} onResetOverrides={onResetOverrides}>
       <div className="flex flex-col gap-2">
         <BorderRadiusControl
           value={frame.borderRadius}

--- a/src/components/Properties/FillSection.tsx
+++ b/src/components/Properties/FillSection.tsx
@@ -37,7 +37,7 @@ const BG_REPEAT_OPTIONS = [
 
 type FillMode = 'solid' | 'image'
 
-export function FillSection({ frame }: { frame: Frame }) {
+export function FillSection({ frame, hasOverrides, onResetOverrides }: { frame: Frame; hasOverrides?: boolean; onResetOverrides?: () => void }) {
   const updateFrame = useFrameStore((s) => s.updateFrame)
   const [mode, setMode] = useState<FillMode>(frame.bgImage ? 'image' : 'solid')
 
@@ -46,7 +46,7 @@ export function FillSection({ frame }: { frame: Frame }) {
     || frame.bgRepeat !== 'repeat'
 
   return (
-    <Section title="Fill">
+    <Section title="Fill" hasOverrides={hasOverrides} onResetOverrides={onResetOverrides}>
       <div className="flex flex-col gap-2">
         {/* Mode toggle */}
         <div className="flex items-center gap-2">

--- a/src/components/Properties/LayoutSection.tsx
+++ b/src/components/Properties/LayoutSection.tsx
@@ -11,7 +11,7 @@ import { SpacingControl } from '../ui/SpacingControl'
 import { SPACING_SCALE, SIZE_CONSTRAINT_SCALE, GRID_COLS_SCALE, GRID_ROWS_SCALE, GROW_SCALE, SHRINK_SCALE, COL_SPAN_SCALE, ROW_SPAN_SCALE, MARGIN_SCALE } from '../../data/scales'
 import { ALIGN_SELF_OPTIONS } from './constants'
 
-export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolean }) {
+export function LayoutSection({ frame, isRoot, hasOverrides, onResetOverrides }: { frame: Frame; isRoot?: boolean; hasOverrides?: boolean; onResetOverrides?: () => void }) {
   const updateFrame = useFrameStore((s) => s.updateFrame)
   const updateSize = useFrameStore((s) => s.updateSize)
   const updateSpacing = useFrameStore((s) => s.updateSpacing)
@@ -53,7 +53,7 @@ export function LayoutSection({ frame, isRoot }: { frame: Frame; isRoot?: boolea
   const currentA = boxFrame?.align === 'stretch' ? 'start' : (boxFrame?.align as 'start' | 'center' | 'end') ?? 'start'
 
   return (
-    <Section title="Layout">
+    <Section title="Layout" hasOverrides={hasOverrides} onResetOverrides={onResetOverrides}>
       <div className="flex flex-col gap-2">
         {/* Display mode */}
         {isBox && (

--- a/src/components/Properties/Properties.tsx
+++ b/src/components/Properties/Properties.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useCallback } from 'react'
 import { useFrameStore } from '../../store/frameStore'
 import { PagePanel } from './PagePanel'
 import { ElementSection } from './ElementSection'
@@ -12,11 +13,42 @@ import { TransformSection } from './TransformSection'
 import { TransitionSection } from './TransitionSection'
 import { AdvancedSection } from './AdvancedSection'
 
+const SECTION_KEYS: Record<string, string[]> = {
+  Layout: ['display', 'direction', 'justify', 'align', 'gap', 'wrap', 'gridCols', 'gridRows', 'padding', 'margin', 'width', 'height', 'minWidth', 'maxWidth', 'minHeight', 'maxHeight', 'grow', 'shrink', 'alignSelf'],
+  Typography: ['fontSize', 'fontWeight', 'lineHeight', 'textAlign'],
+  Fill: ['bg'],
+  Appearance: ['opacity', 'hidden'],
+}
+
+function sectionHasOverrides(section: string, overrideKeys: Set<string>): boolean {
+  const keys = SECTION_KEYS[section]
+  if (!keys) return false
+  return keys.some((k) => overrideKeys.has(k))
+}
+
 export function Properties() {
   const selected = useFrameStore((s) => s.getSelected())
   const multiCount = useFrameStore((s) => s.selectedIds.size)
   const rootId = useFrameStore((s) => s.getRootId())
   const pageSelected = useFrameStore((s) => s.pageSelected)
+  const activeBreakpoint = useFrameStore((s) => s.activeBreakpoint)
+  const getEffectiveFrame = useFrameStore((s) => s.getEffectiveFrame)
+  const removeResponsiveKeys = useFrameStore((s) => s.removeResponsiveKeys)
+
+  // Compute which keys have responsive overrides at the current breakpoint
+  const overrideKeys = useMemo(() => {
+    if (!selected || activeBreakpoint === 'base') return new Set<string>()
+    const overrides = selected.responsive?.[activeBreakpoint]
+    if (!overrides) return new Set<string>()
+    return new Set(Object.keys(overrides))
+  }, [selected, activeBreakpoint])
+
+  const makeResetHandler = useCallback((section: string) => {
+    if (!selected || activeBreakpoint === 'base') return undefined
+    const keys = SECTION_KEYS[section]
+    if (!keys || !sectionHasOverrides(section, overrideKeys)) return undefined
+    return () => removeResponsiveKeys(selected.id, activeBreakpoint as 'md' | 'sm', keys)
+  }, [selected, activeBreakpoint, overrideKeys, removeResponsiveKeys])
 
   if (multiCount > 1) return null
 
@@ -25,22 +57,25 @@ export function Properties() {
     return null
   }
 
+  // Merge responsive overrides for the active breakpoint
+  const effective = activeBreakpoint !== 'base' ? getEffectiveFrame(selected) : selected
+
   const isRoot = selected.id === rootId
-  const hasTextStyles = 'fontSize' in selected
+  const hasTextStyles = 'fontSize' in effective
 
   return (
     <div key={selected.id} className="">
-      <ElementSection frame={selected} isRoot={isRoot} />
-      <PositionSection frame={selected} />
-      <LayoutSection frame={selected} isRoot={isRoot} />
-      {hasTextStyles && <TypographySection frame={selected} />}
-      <AppearanceSection frame={selected} />
-      <FillSection frame={selected} />
-      <BorderSection frame={selected} />
-      <EffectsSection frame={selected} />
-      <TransformSection frame={selected} />
-      <TransitionSection frame={selected} />
-      <AdvancedSection frame={selected} />
+      <ElementSection frame={effective} isRoot={isRoot} />
+      <PositionSection frame={effective} />
+      <LayoutSection frame={effective} isRoot={isRoot} hasOverrides={sectionHasOverrides('Layout', overrideKeys)} onResetOverrides={makeResetHandler('Layout')} />
+      {hasTextStyles && <TypographySection frame={effective} hasOverrides={sectionHasOverrides('Typography', overrideKeys)} onResetOverrides={makeResetHandler('Typography')} />}
+      <AppearanceSection frame={effective} hasOverrides={sectionHasOverrides('Appearance', overrideKeys)} onResetOverrides={makeResetHandler('Appearance')} />
+      <FillSection frame={effective} hasOverrides={sectionHasOverrides('Fill', overrideKeys)} onResetOverrides={makeResetHandler('Fill')} />
+      <BorderSection frame={effective} />
+      <EffectsSection frame={effective} />
+      <TransformSection frame={effective} />
+      <TransitionSection frame={effective} />
+      <AdvancedSection frame={effective} />
     </div>
   )
 }

--- a/src/components/Properties/TypographySection.tsx
+++ b/src/components/Properties/TypographySection.tsx
@@ -17,7 +17,7 @@ const FONT_FAMILY_OPTIONS = [
   { value: 'mono', label: 'Monospace', token: 'mono' },
 ]
 
-export function TypographySection({ frame }: { frame: TextStyles & { id: string } }) {
+export function TypographySection({ frame, hasOverrides, onResetOverrides }: { frame: TextStyles & { id: string }; hasOverrides?: boolean; onResetOverrides?: () => void }) {
   const updateFrame = useFrameStore((s) => s.updateFrame)
 
   const moreActive = frame.fontStyle !== 'normal'
@@ -26,7 +26,7 @@ export function TypographySection({ frame }: { frame: TextStyles & { id: string 
     || frame.whiteSpace !== 'normal'
 
   return (
-    <Section title="Typography">
+    <Section title="Typography" hasOverrides={hasOverrides} onResetOverrides={onResetOverrides}>
       <div className="flex flex-col gap-2">
         {/* Font family */}
         <div className="flex items-center gap-2">

--- a/src/components/RightPanel/RightPanel.tsx
+++ b/src/components/RightPanel/RightPanel.tsx
@@ -1,15 +1,24 @@
-import { Component, Minus, Plus } from 'lucide-react'
+import { Component, Minus, Plus, RotateCcw } from 'lucide-react'
 import { useFrameStore } from '../../store/frameStore'
 import { Properties } from '../Properties/Properties'
 import { ErrorBoundary } from '../ErrorBoundary'
 import { ZOOM_LEVELS } from '../Canvas/ZoomBar'
 import { canvasZoomTo } from '../Canvas/CanvasInline'
 
+const BP_LABELS: Record<string, string> = { md: 'md', sm: 'sm' }
+
 function DesignBar() {
   const canvasZoom = useFrameStore((s) => s.canvasZoom)
   const selectedId = useFrameStore((s) => s.selectedId)
+  const activeBreakpoint = useFrameStore((s) => s.activeBreakpoint)
+  const selected = useFrameStore((s) => s.getSelected())
+  const clearResponsiveOverrides = useFrameStore((s) => s.clearResponsiveOverrides)
   const prevZoom = [...ZOOM_LEVELS].reverse().find((z) => z < canvasZoom - 0.001)
   const nextZoom = ZOOM_LEVELS.find((z) => z > canvasZoom + 0.001)
+
+  const hasOverridesAtBp = activeBreakpoint !== 'base' && selected != null
+    && selected.responsive?.[activeBreakpoint as 'md' | 'sm'] != null
+    && Object.keys(selected.responsive[activeBreakpoint as 'md' | 'sm']!).length > 0
 
   const btn = 'w-5 h-5 flex items-center justify-center shrink-0 rounded text-text-muted hover:text-text-secondary hover:bg-surface-2 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-text-muted'
 
@@ -30,6 +39,23 @@ function DesignBar() {
       >
         <Component size={12} />
       </button>
+
+      {activeBreakpoint !== 'base' && (
+        <div className="flex items-center gap-1">
+          <span className="px-1.5 py-0.5 text-[10px] font-medium leading-none rounded bg-accent/20 text-accent select-none">
+            {BP_LABELS[activeBreakpoint]}
+          </span>
+          {hasOverridesAtBp && (
+            <button
+              onClick={() => clearResponsiveOverrides(selected!.id, activeBreakpoint as 'md' | 'sm')}
+              className="w-4 h-4 flex items-center justify-center rounded text-text-muted hover:text-accent hover:bg-accent/10"
+              title="Reset all overrides at this breakpoint"
+            >
+              <RotateCcw size={10} />
+            </button>
+          )}
+        </div>
+      )}
 
       <div className="flex-1" />
 

--- a/src/components/TreePanel/TreeNode.tsx
+++ b/src/components/TreePanel/TreeNode.tsx
@@ -112,6 +112,25 @@ export function TreeNode({ frame, depth, parentId = null, index = 0, isRoot = fa
   // Drop position (only when hovered and not self-dragging)
   const dropPos = isOver && overPosition && activeId ? overPosition : null
 
+  // Responsive override badges — show which breakpoints have overrides
+  const responsiveBadges = useMemo(() => {
+    const resp = frame.responsive
+    if (!resp) return null
+    const bps: string[] = []
+    if (resp.md && Object.keys(resp.md).length > 0) bps.push('md')
+    if (resp.sm && Object.keys(resp.sm).length > 0) bps.push('sm')
+    if (bps.length === 0) return null
+    return (
+      <span className="flex items-center gap-0.5 shrink-0">
+        {bps.map((bp) => (
+          <span key={bp} className="px-1 py-px text-[9px] leading-none font-medium rounded bg-surface-3/50 text-text-muted select-none">
+            {bp}
+          </span>
+        ))}
+      </span>
+    )
+  }, [frame.responsive])
+
   // Visibility button as trailing
   const trailing = !isRoot ? (
     <button
@@ -158,6 +177,7 @@ export function TreeNode({ frame, depth, parentId = null, index = 0, isRoot = fa
         onMouseLeave={() => hover(null)}
         chevron={chevron}
         onChevronClick={() => toggleCollapse(frame.id)}
+        badges={responsiveBadges}
         trailing={trailing}
         isDragging={isDragging}
         dropPosition={dropPos}

--- a/src/components/TreePanel/TreeRow.tsx
+++ b/src/components/TreePanel/TreeRow.tsx
@@ -22,6 +22,7 @@ export interface TreeRowProps {
   onMouseLeave?: () => void
   chevron?: 'expanded' | 'collapsed' | 'leaf' | 'none'
   onChevronClick?: () => void
+  badges?: React.ReactNode
   trailing?: React.ReactNode
   indent?: number
   isDragging?: boolean
@@ -51,6 +52,7 @@ export function TreeRow({
   onMouseLeave,
   chevron,
   onChevronClick,
+  badges,
   trailing,
   indent,
   isDragging,
@@ -151,8 +153,9 @@ export function TreeRow({
             className={INPUT_CLASS}
           />
         ) : (
-          <span className={`flex-1 h-5 flex items-center text-[12px] truncate ${nameClassName ?? ''}`}>
-            {name}
+          <span className={`flex-1 h-5 flex items-center gap-1.5 text-[12px] truncate ${nameClassName ?? ''}`}>
+            <span className="truncate">{name}</span>
+            {badges}
           </span>
         )}
 

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, RotateCcw } from 'lucide-react'
 
 function getStorageKey(title: string) {
   return `caja-section-${title}`
@@ -19,12 +19,16 @@ export function Section({
   icon,
   collapsible = true,
   defaultCollapsed = false,
+  hasOverrides = false,
+  onResetOverrides,
 }: {
   title: string
   children: React.ReactNode
   icon?: React.ReactNode
   collapsible?: boolean
   defaultCollapsed?: boolean
+  hasOverrides?: boolean
+  onResetOverrides?: () => void
 }) {
   const [collapsed, setCollapsed] = useState(() => collapsible ? readCollapsed(title, defaultCollapsed) : false)
 
@@ -49,6 +53,17 @@ export function Section({
         )}
         {icon && <span className="text-text-muted">{icon}</span>}
         <span className={`c-section-title${collapsible ? ' cursor-pointer select-none' : ''}`} onClick={collapsible ? toggle : undefined}>{title}</span>
+        {hasOverrides && <span className="w-1.5 h-1.5 rounded-full bg-accent shrink-0 ml-1" title="Modified at this breakpoint" />}
+        <div className="flex-1" />
+        {hasOverrides && onResetOverrides && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onResetOverrides() }}
+            className="w-4 h-4 flex items-center justify-center rounded text-text-muted hover:text-text-secondary opacity-0 group-hover/section:opacity-100"
+            title="Reset overrides for this section"
+          >
+            <RotateCcw size={10} />
+          </button>
+        )}
       </div>
       {!collapsed && children}
     </div>

--- a/src/mcp/sanitize.ts
+++ b/src/mcp/sanitize.ts
@@ -213,5 +213,16 @@ export function sanitizeFrameProperties(props: Record<string, unknown>, existing
     if (v) sanitized.border = v
   }
 
+  // responsive: sanitize each breakpoint's overrides
+  if ('responsive' in sanitized && sanitized.responsive && typeof sanitized.responsive === 'object') {
+    const resp = sanitized.responsive as Record<string, unknown>
+    for (const bp of ['md', 'sm'] as const) {
+      if (resp[bp] && typeof resp[bp] === 'object') {
+        resp[bp] = sanitizeFrameProperties(resp[bp] as Record<string, unknown>, existingFrame)
+      }
+    }
+    sanitized.responsive = resp
+  }
+
   return sanitized
 }

--- a/src/mcp/schema.ts
+++ b/src/mcp/schema.ts
@@ -30,7 +30,7 @@ export const toolSchemas = {
 
   update_frame: {
     name: 'update_frame',
-    description: 'Update properties of an existing frame. Settable properties by category:\n\nBooleans: wrap, disabled, hidden, checked.\nEnums: display ("flex"|"inline-flex"|"block"|"inline-block"|"inline"|"grid"), direction ("row"|"column"|"row-reverse"|"column-reverse"), justify, align, overflow, boxShadow, cursor, fontStyle, textDecoration, textAlign, textAlignVertical ("start"|"center"|"end"), textTransform, whiteSpace, alignSelf, objectFit, inputType, border.style, position ("static"|"relative"|"absolute"|"fixed"|"sticky"), bgSize ("auto"|"cover"|"contain"), bgPosition ("center"|"top"|"bottom"|"left"|"right"|"top-left"|"top-right"|"bottom-left"|"bottom-right"), bgRepeat ("repeat"|"no-repeat"|"repeat-x"|"repeat-y"), transition ("none"|"all"|"colors"|"opacity"|"shadow"|"transform"), ease ("linear"|"in"|"out"|"in-out").\nScale (DesignValue<number>): gap, fontSize, fontWeight, lineHeight, letterSpacing, opacity, grow, shrink, minWidth, maxWidth, minHeight, maxHeight, padding.*, margin.*, inset.*, border.top, border.right, border.bottom, border.left (per-side width), borderRadius.*, zIndex, gridCols, gridRows, colSpan, rowSpan, rotate, scaleVal, translateX, translateY, duration, blur, backdropBlur.\nColors (DesignValue<string>): bg, color, border.color.\nText: content, placeholder, src, alt, href, className, htmlId, tailwindClasses, tag, options, rows, bgImage, inputName, inputValue.\nNumbers: min, max, step, defaultValue.\n[Experimental] fontFamily: Google Font name string (e.g. "Playfair Display", "Roboto Mono"). Loads the font automatically.\n\nNumeric and color fields accept either a raw value (number/string) or a DesignValue object: { mode: "custom", value: N } or { mode: "token", token: "4", value: 16 }. Raw values are auto-wrapped with token matching.',
+    description: 'Update properties of an existing frame. When a responsive breakpoint is active (via set_breakpoint), writes go to that breakpoint\'s overrides instead of the base frame.\n\nSettable properties by category:\n\nBooleans: wrap, disabled, hidden, checked.\nEnums: display ("flex"|"inline-flex"|"block"|"inline-block"|"inline"|"grid"), direction ("row"|"column"|"row-reverse"|"column-reverse"), justify, align, overflow, boxShadow, cursor, fontStyle, textDecoration, textAlign, textAlignVertical ("start"|"center"|"end"), textTransform, whiteSpace, alignSelf, objectFit, inputType, border.style, position ("static"|"relative"|"absolute"|"fixed"|"sticky"), bgSize ("auto"|"cover"|"contain"), bgPosition ("center"|"top"|"bottom"|"left"|"right"|"top-left"|"top-right"|"bottom-left"|"bottom-right"), bgRepeat ("repeat"|"no-repeat"|"repeat-x"|"repeat-y"), transition ("none"|"all"|"colors"|"opacity"|"shadow"|"transform"), ease ("linear"|"in"|"out"|"in-out").\nScale (DesignValue<number>): gap, fontSize, fontWeight, lineHeight, letterSpacing, opacity, grow, shrink, minWidth, maxWidth, minHeight, maxHeight, padding.*, margin.*, inset.*, border.top, border.right, border.bottom, border.left (per-side width), borderRadius.*, zIndex, gridCols, gridRows, colSpan, rowSpan, rotate, scaleVal, translateX, translateY, duration, blur, backdropBlur.\nColors (DesignValue<string>): bg, color, border.color.\nText: content, placeholder, src, alt, href, className, htmlId, tailwindClasses, tag, options, rows, bgImage, inputName, inputValue.\nNumbers: min, max, step, defaultValue.\nResponsive: You can also pass responsive overrides directly as properties.responsive: { md: { gap: 8 }, sm: { hidden: true } }. Per-breakpoint objects are deep-merged with existing overrides. However, prefer using set_breakpoint + normal update calls for a cleaner workflow.\n[Experimental] fontFamily: Google Font name string (e.g. "Playfair Display", "Roboto Mono"). Loads the font automatically.\n\nNumeric and color fields accept either a raw value (number/string) or a DesignValue object: { mode: "custom", value: N } or { mode: "token", token: "4", value: 16 }. Raw values are auto-wrapped with token matching.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -51,7 +51,7 @@ export const toolSchemas = {
 
   update_spacing: {
     name: 'update_spacing',
-    description: 'Update padding, margin, or inset of a frame. Values: { top, right, bottom, left }. Each side accepts a number (pixels) or a DesignValue object: { mode: "token", token: "4", value: 16 }. Inset controls top/right/bottom/left offsets for positioned elements.',
+    description: 'Update padding, margin, or inset of a frame. When a responsive breakpoint is active (via set_breakpoint), writes go to that breakpoint\'s overrides. Values: { top, right, bottom, left }. Each side accepts a number (pixels) or a DesignValue object: { mode: "token", token: "4", value: 16 }. Inset controls top/right/bottom/left offsets for positioned elements.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -74,7 +74,7 @@ export const toolSchemas = {
 
   update_size: {
     name: 'update_size',
-    description: 'Update width or height of a frame. Mode can be: default, hug, fill, or fixed. Value accepts a number (pixels) or a DesignValue object: { mode: "token", token: "64", value: 256 }.',
+    description: 'Update width or height of a frame. When a responsive breakpoint is active (via set_breakpoint), writes go to that breakpoint\'s overrides. Mode can be: default, hug, fill, or fixed. Value accepts a number (pixels) or a DesignValue object: { mode: "token", token: "64", value: 256 }.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -364,6 +364,58 @@ export const toolSchemas = {
         url: { type: 'string', description: 'The external image URL to download (must be http:// or https://)' },
       },
       required: ['url'],
+    },
+  },
+
+  // --- Responsive tools ---
+  set_breakpoint: {
+    name: 'set_breakpoint',
+    description: 'Switch the active responsive breakpoint. Desktop-first: "base" = desktop (default), "md" = tablet (≤768px), "sm" = mobile (≤640px). After switching, ALL update_frame/update_spacing/update_size calls write to that breakpoint\'s overrides instead of the base frame. Only changed properties are stored (sparse overrides). The canvas width is also adjusted to match. Call set_breakpoint({ breakpoint: "base" }) to return to desktop editing when done.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        breakpoint: { type: 'string', enum: ['base', 'md', 'sm'], description: 'The breakpoint to activate. "base" = desktop, "md" = tablet ≤768px, "sm" = mobile ≤640px.' },
+      },
+      required: ['breakpoint'],
+    },
+  },
+
+  get_breakpoint: {
+    name: 'get_breakpoint',
+    description: 'Get the currently active responsive breakpoint and canvas width.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+    },
+  },
+
+  get_responsive_overrides: {
+    name: 'get_responsive_overrides',
+    description: 'Get the responsive overrides for a frame. Returns the sparse override objects for each breakpoint (md, sm), or null if no overrides exist. Use this to inspect what properties differ per breakpoint before making changes.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        id: { type: 'string', description: 'ID of the frame to inspect' },
+      },
+      required: ['id'],
+    },
+  },
+
+  clear_responsive_overrides: {
+    name: 'clear_responsive_overrides',
+    description: 'Clear responsive overrides for a frame at a breakpoint. If keys are provided, only those specific properties are removed. If no keys, all overrides at the breakpoint are cleared.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        id: { type: 'string', description: 'ID of the frame' },
+        breakpoint: { type: 'string', enum: ['md', 'sm'], description: 'The breakpoint to clear overrides for' },
+        keys: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional list of specific property keys to remove. If omitted, all overrides at the breakpoint are cleared.',
+        },
+      },
+      required: ['id', 'breakpoint'],
     },
   },
 } as const

--- a/src/mcp/server.mjs
+++ b/src/mcp/server.mjs
@@ -393,6 +393,56 @@ server.tool(
   }
 )
 
+// ── Responsive tools ──
+
+server.tool(
+  'set_breakpoint',
+  'Switch the active responsive breakpoint. Desktop-first: "base" = desktop (default), "md" = tablet (≤768px), "sm" = mobile (≤640px). After switching, ALL update_frame/update_spacing/update_size calls write to that breakpoint\'s overrides instead of the base frame. Only changed properties are stored (sparse overrides). The canvas width is also adjusted to match. Call set_breakpoint({ breakpoint: "base" }) to return to desktop editing when done.',
+  {
+    breakpoint: z.enum(['base', 'md', 'sm']).describe('The breakpoint to activate. "base" = desktop, "md" = tablet ≤768px, "sm" = mobile ≤640px.'),
+  },
+  async ({ breakpoint }) => {
+    const result = await callTool('set_breakpoint', { breakpoint })
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+  }
+)
+
+server.tool(
+  'get_breakpoint',
+  'Get the currently active responsive breakpoint and canvas width.',
+  {},
+  async () => {
+    const result = await callTool('get_breakpoint', {})
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+  }
+)
+
+server.tool(
+  'get_responsive_overrides',
+  'Get the responsive overrides for a frame. Returns the sparse override objects for each breakpoint (md, sm), or null if no overrides exist. Use this to inspect what properties differ per breakpoint before making changes.',
+  {
+    id: z.string().describe('ID of the frame to inspect'),
+  },
+  async ({ id }) => {
+    const result = await callTool('get_responsive_overrides', { id })
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+  }
+)
+
+server.tool(
+  'clear_responsive_overrides',
+  'Clear responsive overrides for a frame at a breakpoint. If keys are provided, only those specific properties are removed. If no keys, all overrides at the breakpoint are cleared.',
+  {
+    id: z.string().describe('ID of the frame'),
+    breakpoint: z.enum(['md', 'sm']).describe('The breakpoint to clear overrides for'),
+    keys: z.array(z.string()).optional().describe('Optional list of specific property keys to remove. If omitted, all overrides at the breakpoint are cleared.'),
+  },
+  async ({ id, breakpoint, keys }) => {
+    const result = await callTool('clear_responsive_overrides', { id, breakpoint, keys })
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+  }
+)
+
 // ── Resources ──
 
 server.resource(

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -3,7 +3,7 @@
 
 import { useFrameStore, findInTree, cloneWithNewIds, normalizeFrame } from '../store/frameStore'
 import { useCatalogStore } from '../store/catalogStore'
-import type { Frame, SizeValue } from '../types/frame'
+import type { Frame, SizeValue, Breakpoint, ResponsiveOverrides } from '../types/frame'
 import type { ToolName } from './schema'
 import { parseTailwindClasses } from '../utils/parseTailwindClasses'
 import { exportLibrary } from '../lib/libraryOps'
@@ -58,6 +58,11 @@ export function summaryTree(frame: Frame): Record<string, unknown> {
     node.display = frame.display
     node.childCount = frame.children.length
     node.children = frame.children.map(summaryTree)
+  }
+  // Flag frames with responsive overrides so agents know they exist
+  if (frame.responsive) {
+    const bps = Object.keys(frame.responsive).filter((k) => frame.responsive?.[k as 'md' | 'sm'])
+    if (bps.length > 0) node.responsive = bps
   }
   return node
 }
@@ -179,6 +184,19 @@ const handlers: Record<string, ToolHandler> = {
     }
 
     const sanitized = sanitizeFrameProperties(mergedProps, frame)
+
+    // Deep-merge responsive: merge per-breakpoint instead of replacing the whole object
+    if (sanitized.responsive && typeof sanitized.responsive === 'object' && frame.responsive) {
+      const incoming = sanitized.responsive as Record<string, ResponsiveOverrides | undefined>
+      const merged: Frame['responsive'] = { ...frame.responsive }
+      for (const bp of ['md', 'sm'] as const) {
+        if (incoming[bp]) {
+          merged[bp] = { ...(merged[bp] ?? {}), ...incoming[bp] }
+        }
+      }
+      sanitized.responsive = merged
+    }
+
     store.updateFrame(id, sanitized as Partial<Frame>)
     const updated = findInTree(getStore().root, id)
     return { success: true, data: updated ? compactSnapshot(updated) : undefined }
@@ -583,6 +601,76 @@ const handlers: Record<string, ToolHandler> = {
     if (!page) return { success: false, error: `Page ${id} not found` }
     store.removePage(id)
     return { success: true, data: { removed: id } }
+  },
+
+  // --- Responsive tools ---
+
+  set_breakpoint(params) {
+    const { breakpoint } = params as { breakpoint: Breakpoint }
+    const valid: Breakpoint[] = ['base', 'md', 'sm']
+    if (!valid.includes(breakpoint)) {
+      return { success: false, error: `Invalid breakpoint "${breakpoint}". Must be one of: base, md, sm` }
+    }
+    const store = getStore()
+    // Sync canvas width to match breakpoint
+    const widthMap: Record<Breakpoint, number | null> = { base: null, md: 767, sm: 375 }
+    store.setCanvasWidth(widthMap[breakpoint])
+    store.setActiveBreakpoint(breakpoint)
+    return {
+      success: true,
+      data: { breakpoint, canvasWidth: widthMap[breakpoint] },
+      hint: breakpoint === 'base'
+        ? 'Editing base (desktop) properties. All update_frame/update_spacing/update_size calls write to the base frame.'
+        : `Editing ${breakpoint} overrides. All update_frame/update_spacing/update_size calls now write to the ${breakpoint} breakpoint. Only changed properties are stored as overrides. Call set_breakpoint({ breakpoint: "base" }) when done to return to desktop editing.`,
+    }
+  },
+
+  get_breakpoint() {
+    const store = getStore()
+    return {
+      success: true,
+      data: { breakpoint: store.activeBreakpoint, canvasWidth: store.canvasWidth },
+    }
+  },
+
+  get_responsive_overrides(params) {
+    const { id } = params as { id: string }
+    const store = getStore()
+    const frame = findInTree(store.root, id)
+    if (!frame) return { success: false, error: `Frame ${id} not found` }
+    return {
+      success: true,
+      data: {
+        id: frame.id,
+        name: frame.name,
+        responsive: frame.responsive ?? null,
+      },
+    }
+  },
+
+  clear_responsive_overrides(params) {
+    const { id, breakpoint, keys } = params as { id: string; breakpoint: 'md' | 'sm'; keys?: string[] }
+    const store = getStore()
+    const frame = findInTree(store.root, id)
+    if (!frame) return { success: false, error: `Frame ${id} not found` }
+    if (breakpoint !== 'md' && breakpoint !== 'sm') {
+      return { success: false, error: `Invalid breakpoint "${breakpoint}". Must be "md" or "sm"` }
+    }
+    if (keys && keys.length > 0) {
+      store.removeResponsiveKeys(id, breakpoint, keys)
+    } else {
+      store.clearResponsiveOverrides(id, breakpoint)
+    }
+    const updated = findInTree(getStore().root, id)
+    return {
+      success: true,
+      data: {
+        id,
+        breakpoint,
+        cleared: keys || 'all',
+        responsive: updated?.responsive ?? null,
+      },
+    }
   },
 
   async upload_asset(params) {

--- a/src/store/frameFactories.ts
+++ b/src/store/frameFactories.ts
@@ -102,10 +102,23 @@ export function cloneSizeValue(sv: SizeValue | undefined): SizeValue | undefined
   return { mode: sv.mode, value: cloneDV(sv.value)! }
 }
 
+// Deep clone responsive overrides
+function cloneResponsive(responsive: Frame['responsive']): Frame['responsive'] {
+  if (!responsive) return undefined
+  const result: Frame['responsive'] = {}
+  for (const key of ['md', 'sm'] as const) {
+    const ov = responsive[key]
+    if (!ov) continue
+    result[key] = JSON.parse(JSON.stringify(ov))
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
 // Deep clone helper
 export function cloneTree(frame: Frame): Frame {
   const base = {
     ...frame,
+    responsive: cloneResponsive(frame.responsive),
     padding: cloneSpacing(frame.padding),
     margin: cloneSpacing(frame.margin),
     inset: cloneSpacing(frame.inset),

--- a/src/store/frameMigration.ts
+++ b/src/store/frameMigration.ts
@@ -216,6 +216,11 @@ export function migrateFrame(raw: Record<string, unknown>): Frame {
   if (raw._componentId) result._componentId = raw._componentId as string
   if (raw._overrides) result._overrides = raw._overrides as Record<string, Record<string, unknown>>
 
+  // Preserve responsive overrides
+  if (raw.responsive && typeof raw.responsive === 'object') {
+    result.responsive = raw.responsive as Frame['responsive']
+  }
+
   // Final pass: normalizeFrame fills in any fields the manual migration missed
   // (e.g. new fields added to types that haven't been added to migrateFrame yet)
   return normalizeFrame(result)

--- a/src/store/frameStore.ts
+++ b/src/store/frameStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { Frame, BoxElement, TextElement, ImageElement, ButtonElement, InputElement, TextareaElement, SelectElement, DesignValue, Spacing, SizeValue, BorderRadius, Page } from '../types/frame'
+import type { Frame, BoxElement, TextElement, ImageElement, ButtonElement, InputElement, TextareaElement, SelectElement, DesignValue, Spacing, SizeValue, BorderRadius, Page, Breakpoint, ResponsiveOverrides } from '../types/frame'
 import { useCatalogStore } from './catalogStore'
 import {
   createBox, createText, createImage, createButton, createInput,
@@ -253,6 +253,7 @@ interface FrameStore {
   dirty: boolean
   previewMode: boolean
   canvasWidth: number | null
+  activeBreakpoint: Breakpoint
   canvasZoom: number
   mcpConnected: boolean
   mcpBusy: boolean
@@ -302,6 +303,8 @@ interface FrameStore {
   updateFrame: (id: string, updates: Partial<Frame>) => void
   updateSpacing: (id: string, field: 'padding' | 'margin' | 'inset', values: Partial<Spacing>) => void
   updateSize: (id: string, dimension: 'width' | 'height', size: Partial<SizeValue>) => void
+  clearResponsiveOverrides: (id: string, bp: 'md' | 'sm') => void
+  removeResponsiveKeys: (id: string, bp: 'md' | 'sm', keys: string[]) => void
   updateBorderRadius: (id: string, values: Partial<BorderRadius>) => void
   renameFrame: (id: string, name: string) => void
 
@@ -323,6 +326,8 @@ interface FrameStore {
   togglePreviewMode: () => void
   setPreviewMode: (value: boolean) => void
   setCanvasWidth: (width: number | null) => void
+  setActiveBreakpoint: (bp: Breakpoint) => void
+  getEffectiveFrame: (frame: Frame) => Frame
   setCanvasZoom: (zoom: number) => void
   setCanvasDrag: (id: string | null) => void
   setCanvasDragOver: (over: { parentId: string; index: number } | null) => void
@@ -364,6 +369,7 @@ const VIEW_PREFS_KEY = 'caja-view-prefs'
 interface ViewPrefs {
   previewMode: boolean
   canvasWidth: number | null
+  activeBreakpoint: Breakpoint
   advancedMode: boolean
   collapsedIds: string[]
 }
@@ -376,12 +382,13 @@ function loadViewPrefs(): ViewPrefs {
       return {
         previewMode: parsed.previewMode ?? false,
         canvasWidth: parsed.canvasWidth ?? null,
+        activeBreakpoint: (['base', 'md', 'sm'].includes(parsed.activeBreakpoint) ? parsed.activeBreakpoint : 'base') as Breakpoint,
         advancedMode: parsed.advancedMode ?? false,
         collapsedIds: parsed.collapsedIds ?? [],
       }
     }
   } catch (err) { console.warn('Failed to load view preferences:', err) }
-  return { previewMode: false, canvasWidth: null, advancedMode: false, collapsedIds: [] }
+  return { previewMode: false, canvasWidth: null, activeBreakpoint: 'base' as Breakpoint, advancedMode: false, collapsedIds: [] }
 }
 
 function saveViewPrefs(prefs: Partial<ViewPrefs>) {
@@ -412,6 +419,29 @@ function updateActiveRoot(state: { pages: Page[]; activePageId: string }, newRoo
     root: newRoot,
     pages: state.pages.map((p) => p.id === state.activePageId ? { ...p, root: newRoot } : p),
   }
+}
+
+/** Merge responsive overrides onto a base frame (desktop-first cascade).
+ *  At 'md': apply md overrides.
+ *  At 'sm': apply md overrides first, then sm on top. */
+function mergeResponsiveOverrides(frame: Frame, bp: 'md' | 'sm'): Frame {
+  const resp = frame.responsive
+  if (!resp) return frame
+  let result = frame as Frame
+  // Desktop-first cascade: md always applies at sm too
+  if (bp === 'sm' || bp === 'md') {
+    const md = resp.md
+    if (md && Object.keys(md).length > 0) {
+      result = { ...result, ...md } as Frame
+    }
+  }
+  if (bp === 'sm') {
+    const sm = resp.sm
+    if (sm && Object.keys(sm).length > 0) {
+      result = { ...result, ...sm } as Frame
+    }
+  }
+  return result
 }
 
 export const COMPONENT_PAGE_ID = '__components__'
@@ -582,6 +612,7 @@ export const useFrameStore = create<FrameStore>((set, get) => ({
   dirty: false,
   previewMode: initialViewPrefs.previewMode,
   canvasWidth: initialViewPrefs.canvasWidth,
+  activeBreakpoint: initialViewPrefs.activeBreakpoint,
   canvasZoom: 1,
   canvasTool: 'pointer',
   pendingTextEdit: null,
@@ -1055,27 +1086,82 @@ export const useFrameStore = create<FrameStore>((set, get) => ({
 
   updateFrame: (id, updates) =>
     set((state) => {
+      const bp = state.activeBreakpoint
       const history = pushHistory(state)
-      const newRoot = updateInTree(state.root, id, (f) => ({ ...f, ...updates } as Frame)) as BoxElement
+      if (bp === 'base') {
+        const newRoot = updateInTree(state.root, id, (f) => ({ ...f, ...updates } as Frame)) as BoxElement
+        return { ...updateActiveRoot(state, newRoot), ...history }
+      }
+      // Write to responsive overrides
+      const newRoot = updateInTree(state.root, id, (f) => {
+        const existing = f.responsive?.[bp] ?? {}
+        const merged = { ...existing, ...updates } as ResponsiveOverrides
+        // Remove keys that match the base value (keep overrides sparse)
+        for (const key of Object.keys(merged) as (keyof ResponsiveOverrides)[]) {
+          if (JSON.stringify(merged[key]) === JSON.stringify((f as Record<string, unknown>)[key])) {
+            delete merged[key]
+          }
+        }
+        const responsive = { ...f.responsive, [bp]: Object.keys(merged).length > 0 ? merged : undefined }
+        // Clean up empty responsive object
+        if (!responsive.md && !responsive.sm) return { ...f, responsive: undefined } as Frame
+        return { ...f, responsive } as Frame
+      }) as BoxElement
       return { ...updateActiveRoot(state, newRoot), ...history }
     }),
 
   updateSpacing: (id, field, values) =>
     set((state) => {
+      const bp = state.activeBreakpoint
       const history = pushHistory(state)
       const ZERO: DesignValue<number> = { mode: 'custom', value: 0 }
-      const existing = (f: Frame) => {
+      const existingSpacing = (f: Frame) => {
         const s = f[field] as Spacing | undefined
         return { top: s?.top ?? ZERO, right: s?.right ?? ZERO, bottom: s?.bottom ?? ZERO, left: s?.left ?? ZERO }
       }
-      const newRoot = updateInTree(state.root, id, (f) => ({ ...f, [field]: { ...existing(f), ...values } })) as BoxElement
+      if (bp === 'base') {
+        const newRoot = updateInTree(state.root, id, (f) => ({ ...f, [field]: { ...existingSpacing(f), ...values } })) as BoxElement
+        return { ...updateActiveRoot(state, newRoot), ...history }
+      }
+      // Write spacing to responsive overrides
+      const newRoot = updateInTree(state.root, id, (f) => {
+        const existingOverride = (f.responsive?.[bp]?.[field as keyof ResponsiveOverrides] ?? existingSpacing(f)) as Spacing
+        const newSpacing = { ...existingOverride, ...values }
+        const existing = f.responsive?.[bp] ?? {}
+        const merged = { ...existing, [field]: newSpacing } as ResponsiveOverrides
+        // Remove if matches base
+        if (JSON.stringify(merged[field as keyof ResponsiveOverrides]) === JSON.stringify(f[field])) {
+          delete merged[field as keyof ResponsiveOverrides]
+        }
+        const responsive = { ...f.responsive, [bp]: Object.keys(merged).length > 0 ? merged : undefined }
+        if (!responsive.md && !responsive.sm) return { ...f, responsive: undefined } as Frame
+        return { ...f, responsive } as Frame
+      }) as BoxElement
       return { ...updateActiveRoot(state, newRoot), ...history }
     }),
 
   updateSize: (id, dimension, size) =>
     set((state) => {
+      const bp = state.activeBreakpoint
       const history = pushHistory(state)
-      const newRoot = updateInTree(state.root, id, (f) => ({ ...f, [dimension]: { ...f[dimension], ...size } })) as BoxElement
+      if (bp === 'base') {
+        const newRoot = updateInTree(state.root, id, (f) => ({ ...f, [dimension]: { ...f[dimension], ...size } })) as BoxElement
+        return { ...updateActiveRoot(state, newRoot), ...history }
+      }
+      // Write size to responsive overrides
+      const newRoot = updateInTree(state.root, id, (f) => {
+        const existingOverride = (f.responsive?.[bp]?.[dimension as keyof ResponsiveOverrides] ?? f[dimension]) as SizeValue
+        const newSize = { ...existingOverride, ...size }
+        const existing = f.responsive?.[bp] ?? {}
+        const merged = { ...existing, [dimension]: newSize } as ResponsiveOverrides
+        // Remove if matches base
+        if (JSON.stringify(merged[dimension as keyof ResponsiveOverrides]) === JSON.stringify(f[dimension])) {
+          delete merged[dimension as keyof ResponsiveOverrides]
+        }
+        const responsive = { ...f.responsive, [bp]: Object.keys(merged).length > 0 ? merged : undefined }
+        if (!responsive.md && !responsive.sm) return { ...f, responsive: undefined } as Frame
+        return { ...f, responsive } as Frame
+      }) as BoxElement
       return { ...updateActiveRoot(state, newRoot), ...history }
     }),
 
@@ -1090,6 +1176,34 @@ export const useFrameStore = create<FrameStore>((set, get) => ({
     set((state) => {
       const history = pushHistory(state)
       const newRoot = updateInTree(state.root, id, (f) => ({ ...f, name })) as BoxElement
+      return { ...updateActiveRoot(state, newRoot), ...history }
+    }),
+
+  clearResponsiveOverrides: (id, bp) =>
+    set((state) => {
+      const history = pushHistory(state)
+      const newRoot = updateInTree(state.root, id, (f) => {
+        const responsive = { ...f.responsive, [bp]: undefined }
+        if (!responsive.md && !responsive.sm) return { ...f, responsive: undefined } as Frame
+        return { ...f, responsive } as Frame
+      }) as BoxElement
+      return { ...updateActiveRoot(state, newRoot), ...history }
+    }),
+
+  removeResponsiveKeys: (id, bp, keys) =>
+    set((state) => {
+      const history = pushHistory(state)
+      const newRoot = updateInTree(state.root, id, (f) => {
+        const existing = f.responsive?.[bp]
+        if (!existing) return f
+        const updated = { ...existing }
+        for (const key of keys) {
+          delete updated[key as keyof typeof updated]
+        }
+        const responsive = { ...f.responsive, [bp]: Object.keys(updated).length > 0 ? updated : undefined }
+        if (!responsive.md && !responsive.sm) return { ...f, responsive: undefined } as Frame
+        return { ...f, responsive } as Frame
+      }) as BoxElement
       return { ...updateActiveRoot(state, newRoot), ...history }
     }),
 
@@ -1259,6 +1373,15 @@ export const useFrameStore = create<FrameStore>((set, get) => ({
     saveViewPrefs({ previewMode: s.previewMode, canvasWidth: width, advancedMode: s.advancedMode })
     return { canvasWidth: width }
   }),
+  setActiveBreakpoint: (bp) => {
+    saveViewPrefs({ activeBreakpoint: bp })
+    set({ activeBreakpoint: bp })
+  },
+  getEffectiveFrame: (frame) => {
+    const bp = get().activeBreakpoint
+    if (bp === 'base') return frame
+    return mergeResponsiveOverrides(frame, bp)
+  },
   setCanvasZoom: (zoom) => set({ canvasZoom: zoom }),
   setCanvasTool: (tool) => set({ canvasTool: tool }),
   clearPendingTextEdit: () => set({ pendingTextEdit: null }),

--- a/src/types/frame.ts
+++ b/src/types/frame.ts
@@ -105,6 +105,9 @@ interface BaseElement {
   // Advanced
   tailwindClasses: string
 
+  // Responsive overrides — sparse per-breakpoint property patches (desktop-first)
+  responsive?: Partial<Record<'md' | 'sm', ResponsiveOverrides>>
+
   // Origin tracking — populated when inserting from a component source (passive, informational)
   _origin?: { libraryId?: string; componentId?: string }
 
@@ -235,6 +238,26 @@ export interface Page {
   root: BoxElement
   isComponentPage?: boolean  // hidden page that stores component masters
 }
+
+// Responsive breakpoints — desktop-first: base = desktop, md ≤768px, sm ≤640px
+export type Breakpoint = 'base' | 'md' | 'sm'
+
+// Sparse partial overrides — only properties that differ from base
+export type ResponsiveOverrides = Partial<
+  Pick<BaseElement,
+    | 'width' | 'height' | 'padding' | 'margin'
+    | 'minWidth' | 'maxWidth' | 'minHeight' | 'maxHeight'
+    | 'grow' | 'shrink' | 'alignSelf'
+    | 'bg' | 'opacity' | 'hidden'
+  > &
+  Pick<BoxElement,
+    | 'display' | 'direction' | 'justify' | 'align' | 'gap' | 'wrap'
+    | 'gridCols' | 'gridRows'
+  > &
+  Pick<TextStyles,
+    | 'fontSize' | 'fontWeight' | 'lineHeight' | 'textAlign'
+  >
+>
 
 // Union type
 export type Frame = BoxElement | TextElement | ImageElement | ButtonElement | InputElement | TextareaElement | SelectElement

--- a/src/utils/frameToClasses.ts
+++ b/src/utils/frameToClasses.ts
@@ -1,4 +1,4 @@
-import type { Frame, Spacing, Inset, BorderRadius, Border, DesignValue } from '../types/frame'
+import type { Frame, Spacing, Inset, BorderRadius, Border, DesignValue, ResponsiveOverrides } from '../types/frame'
 import { toGoogleFontClass } from './googleFonts'
 import { resolveRenderSrc } from '../lib/assetOps'
 
@@ -427,9 +427,147 @@ export function frameToClasses(frame: Frame): string {
   // Manual classes (user-added)
   if (frame.tailwindClasses) cls.push(frame.tailwindClasses)
 
+  // Responsive override classes
+  const responsiveClasses = generateResponsiveClasses(frame)
+  if (responsiveClasses) cls.push(responsiveClasses)
+
   return cls.join(' ')
   } catch (err) {
     console.warn(`[frameToClasses] Error for frame ${frame?.id}:`, err)
     return frame?.tailwindClasses || ''
   }
+}
+
+/**
+ * Generate prefixed classes for responsive overrides.
+ * Desktop-first: max-md: for tablet, max-sm: for mobile.
+ */
+function generateResponsiveClasses(frame: Frame): string {
+  if (!frame.responsive) return ''
+  const cls: string[] = []
+  const bps: Array<{ key: 'md' | 'sm'; prefix: string }> = [
+    { key: 'md', prefix: 'max-md:' },
+    { key: 'sm', prefix: 'max-sm:' },
+  ]
+  for (const { key, prefix } of bps) {
+    const overrides = frame.responsive[key]
+    if (!overrides || Object.keys(overrides).length === 0) continue
+    cls.push(...overrideClasses(overrides, frame, prefix))
+  }
+  return cls.join(' ')
+}
+
+/** Generate Tailwind classes for a sparse set of responsive overrides. */
+function overrideClasses(ov: ResponsiveOverrides, base: Frame, prefix: string): string[] {
+  const cls: string[] = []
+  const p = (c: string) => `${prefix}${c}`
+
+  // Hidden
+  if (ov.hidden !== undefined) cls.push(p(ov.hidden ? 'hidden' : 'block'))
+
+  // Display / direction / justify / align / gap / wrap (box-only)
+  if (ov.display !== undefined) {
+    if (ov.display === 'flex' || ov.display === 'inline-flex') {
+      cls.push(p(ov.display === 'inline-flex' ? 'inline-flex' : 'flex'))
+    } else if (ov.display === 'grid') {
+      cls.push(p('grid'))
+    } else if (ov.display !== 'block') {
+      cls.push(p(ov.display))
+    } else {
+      cls.push(p('block'))
+    }
+  }
+  if (ov.direction !== undefined) {
+    const dirMap: Record<string, string> = { row: 'flex-row', column: 'flex-col', 'row-reverse': 'flex-row-reverse', 'column-reverse': 'flex-col-reverse' }
+    cls.push(p(dirMap[ov.direction] ?? 'flex-col'))
+  }
+  if (ov.justify !== undefined) {
+    const justifyMap: Record<string, string> = { start: 'justify-start', center: 'justify-center', end: 'justify-end', between: 'justify-between', around: 'justify-around' }
+    if (justifyMap[ov.justify]) cls.push(p(justifyMap[ov.justify]))
+  }
+  if (ov.align !== undefined) {
+    const alignMap: Record<string, string> = { start: 'items-start', center: 'items-center', end: 'items-end', stretch: 'items-stretch' }
+    if (alignMap[ov.align]) cls.push(p(alignMap[ov.align]))
+  }
+  if (ov.gap !== undefined && !dvIsZero(ov.gap)) cls.push(p(dvClass('gap', ov.gap)))
+  if (ov.wrap !== undefined) cls.push(p(ov.wrap ? 'flex-wrap' : 'flex-nowrap'))
+  if (ov.gridCols !== undefined && !dvIsZero(ov.gridCols)) cls.push(p(dvClass('grid-cols', ov.gridCols, '')))
+  if (ov.gridRows !== undefined && !dvIsZero(ov.gridRows)) cls.push(p(dvClass('grid-rows', ov.gridRows, '')))
+
+  // Size
+  if (ov.width !== undefined) {
+    if (ov.width.mode === 'hug') cls.push(p('w-fit'))
+    else if (ov.width.mode === 'fill') cls.push(p('w-full'))
+    else if (ov.width.mode === 'fixed') cls.push(p(dvClass('w', ov.width.value)))
+    else cls.push(p('w-auto'))
+  }
+  if (ov.height !== undefined) {
+    if (ov.height.mode === 'hug') cls.push(p('h-fit'))
+    else if (ov.height.mode === 'fill') cls.push(p('h-full'))
+    else if (ov.height.mode === 'fixed') cls.push(p(dvClass('h', ov.height.value)))
+    else cls.push(p('h-auto'))
+  }
+
+  // Spacing
+  if (ov.padding !== undefined) {
+    for (const c of spacingClasses('p', ov.padding)) cls.push(p(c))
+  }
+  if (ov.margin !== undefined) {
+    for (const c of spacingClasses('m', ov.margin)) cls.push(p(c))
+  }
+
+  // Size constraints
+  if (ov.minWidth !== undefined) { if (!dvIsZero(ov.minWidth)) cls.push(p(dvClass('min-w', ov.minWidth))); else cls.push(p('min-w-0')) }
+  if (ov.maxWidth !== undefined) { if (!dvIsZero(ov.maxWidth)) cls.push(p(dvClass('max-w', ov.maxWidth))); else cls.push(p('max-w-none')) }
+  if (ov.minHeight !== undefined) { if (!dvIsZero(ov.minHeight)) cls.push(p(dvClass('min-h', ov.minHeight))); else cls.push(p('min-h-0')) }
+  if (ov.maxHeight !== undefined) { if (!dvIsZero(ov.maxHeight)) cls.push(p(dvClass('max-h', ov.maxHeight))); else cls.push(p('max-h-none')) }
+
+  // Flex grow / shrink
+  if (ov.grow !== undefined) {
+    const growVal = ov.grow.value
+    if (growVal === 0) cls.push(p('grow-0'))
+    else if (growVal === 1) cls.push(p('grow'))
+    else cls.push(p(`grow-[${growVal}]`))
+  }
+  if (ov.shrink !== undefined) {
+    const shrinkVal = ov.shrink.value
+    if (shrinkVal === 0) cls.push(p('shrink-0'))
+    else if (shrinkVal === 1) cls.push(p('shrink'))
+    else cls.push(p(`shrink-[${shrinkVal}]`))
+  }
+
+  // Align self
+  if (ov.alignSelf !== undefined && ov.alignSelf !== 'auto') {
+    const selfMapLocal: Record<string, string> = { start: 'self-start', center: 'self-center', end: 'self-end', stretch: 'self-stretch' }
+    if (selfMapLocal[ov.alignSelf]) cls.push(p(selfMapLocal[ov.alignSelf]))
+  }
+
+  // Background
+  if (ov.bg !== undefined && ov.bg.value) cls.push(p(dvColorClass('bg', ov.bg)))
+
+  // Opacity
+  if (ov.opacity !== undefined) {
+    if (ov.opacity.mode === 'token') cls.push(p(`opacity-${ov.opacity.token}`))
+    else if (ov.opacity.value < 100) cls.push(p(`opacity-[${ov.opacity.value / 100}]`))
+  }
+
+  // Text styles
+  if (ov.fontSize !== undefined && !dvIsZero(ov.fontSize)) {
+    if (ov.fontSize.mode === 'token') cls.push(p(`text-${ov.fontSize.token}`))
+    else cls.push(p(`text-[${ov.fontSize.value}px]`))
+  }
+  if (ov.fontWeight !== undefined && ov.fontWeight.value !== 400) {
+    if (ov.fontWeight.mode === 'token') cls.push(p(`font-${ov.fontWeight.token}`))
+    else {
+      const w = weightMap[ov.fontWeight.value]
+      cls.push(p(w || `font-[${ov.fontWeight.value}]`))
+    }
+  }
+  if (ov.lineHeight !== undefined && !dvIsZero(ov.lineHeight)) {
+    if (ov.lineHeight.mode === 'token') cls.push(p(`leading-${ov.lineHeight.token}`))
+    else cls.push(p(`leading-[${ov.lineHeight.value}]`))
+  }
+  if (ov.textAlign !== undefined && ov.textAlign !== 'left') cls.push(p(`text-${ov.textAlign}`))
+
+  return cls
 }

--- a/src/utils/responsiveClasses.ts
+++ b/src/utils/responsiveClasses.ts
@@ -1,13 +1,30 @@
 /**
- * Convert viewport responsive prefixes (sm:, md:, max-md:, etc.)
- * to container query prefixes (@sm:, @md:, @max-md:, etc.).
+ * Convert viewport responsive prefixes (max-md:, max-sm:, etc.)
+ * to container query prefixes with explicit pixel breakpoints.
+ *
+ * Tailwind v4's named container breakpoints (@max-md = 28rem = 448px)
+ * don't match viewport breakpoints (max-md = 768px). We use arbitrary
+ * pixel values so the canvas container queries fire at the correct widths.
  *
  * Used by FrameRenderer at render time so the inline canvas
  * responds to its container width instead of the viewport.
- * Export still calls frameToClasses() directly — standard `md:` prefixes.
+ * Export still calls frameToClasses() directly — standard `max-md:` prefixes.
  */
+
+// Viewport breakpoint → pixel value mapping
+const BP_PX: Record<string, number> = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  '2xl': 1536,
+}
+
 const RE = /\b(max-)?(sm|md|lg|xl|2xl):/g
 
 export function toContainerQueries(classes: string): string {
-  return classes.replace(RE, (_, max, bp) => max ? `@max-${bp}:` : `@${bp}:`)
+  return classes.replace(RE, (_, max, bp) => {
+    const px = BP_PX[bp]
+    return max ? `@max-[${px}px]:` : `@min-[${px}px]:`
+  })
 }


### PR DESCRIPTION
## Summary
- **Responsive breakpoints**: Desktop-first system (md ≤768px, sm ≤640px) with store routing, sparse override storage, and Tailwind class generation
- **Override indicators**: Accent dots on property sections, muted pills (md/sm) in tree panel, dots on toolbar breakpoint menu
- **Reset actions**: Per-section reset, global reset via DesignBar pill, undo support, and `clear_responsive_overrides` MCP tool
- **MCP tools**: `set_breakpoint`, `get_breakpoint`, `get_responsive_overrides`, `clear_responsive_overrides` for full agent workflow

## Test plan
- [ ] Switch to Tablet/Mobile → modify properties → verify overrides stored sparsely
- [ ] Select frame with overrides → accent dots visible on Layout/Typography/Fill/Appearance sections
- [ ] Tree panel shows `md`/`sm` pills next to frames with overrides
- [ ] Reset per-section via hover button → overrides cleared, dot disappears
- [ ] Reset all via DesignBar pill → all overrides at breakpoint cleared
- [ ] Undo after reset → overrides restored
- [ ] Toolbar breakpoint menu shows dots on icons when overrides exist
- [ ] MCP: `clear_responsive_overrides({ id, breakpoint })` clears overrides
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)