### PR TITLE
Unify modal styling across all modals

### DIFF
--- a/src/components/Export/ExportModal.tsx
+++ b/src/components/Export/ExportModal.tsx
@@ -3,6 +3,7 @@ import { exportToJSX } from '../../utils/exportTailwind'
 import { exportToHTML, exportToHTMLDocument } from '../../utils/exportHtml'
 import { useMemo, useState } from 'react'
 import { Dialog } from '../ui/Dialog'
+import { X } from 'lucide-react'
 import * as RadixTabs from '@radix-ui/react-tabs'
 
 interface ExportModalProps {
@@ -48,43 +49,40 @@ export function ExportModal({ open, onOpenChange }: ExportModalProps) {
       <RadixTabs.Root
         value={format}
         onValueChange={(v) => setFormat(v as ExportFormat)}
-        className="bg-surface-1 border border-border-accent rounded-xl w-[640px] max-h-[80vh] flex flex-col shadow-2xl"
+        className="bg-surface-1 border border-border rounded-xl w-[640px] max-h-[80vh] flex flex-col shadow-xl"
       >
+        {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-          <div className="flex items-center gap-1">
-            <span className="text-[12px] text-text-secondary font-medium mr-2">Export</span>
-            <RadixTabs.List className="flex items-center gap-0.5">
-              {FORMAT_TABS.map((tab) => (
-                <RadixTabs.Trigger
-                  key={tab.value}
-                  value={tab.value}
-                  className={`px-2.5 py-1 text-[12px] rounded-md transition-all ${
-                    format === tab.value
-                      ? 'bg-surface-2 text-text-primary'
-                      : 'text-text-muted hover:text-text-secondary'
-                  }`}
-                >
-                  {tab.label}
-                </RadixTabs.Trigger>
-              ))}
-            </RadixTabs.List>
-          </div>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              className="px-3 py-1.5 text-[12px] bg-accent text-surface-0 font-medium rounded-md hover:opacity-85 transition-opacity"
-              onClick={handleCopy}
-            >
-              {copied ? 'Copied!' : 'Copy'}
-            </button>
-            <button
-              type="button"
-              className="px-3 py-1.5 text-[12px] text-text-muted hover:text-text-primary bg-surface-2 hover:bg-surface-3 rounded-md transition-all"
-              onClick={() => onOpenChange(false)}
-            >
-              Close
-            </button>
-          </div>
+          <h2 className="text-[13px] font-semibold text-text-primary">Export</h2>
+          <button className="w-5 h-5 c-icon-btn hover:text-text-secondary hover:bg-surface-2/60" onClick={() => onOpenChange(false)}>
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Tabs + Copy */}
+        <div className="flex items-center justify-between px-4 pt-3 pb-3">
+          <RadixTabs.List className="flex items-center gap-0.5">
+            {FORMAT_TABS.map((tab) => (
+              <RadixTabs.Trigger
+                key={tab.value}
+                value={tab.value}
+                className={`px-2.5 py-1.5 text-[12px] rounded-md transition-all ${
+                  format === tab.value
+                    ? 'bg-surface-3 text-text-primary'
+                    : 'text-text-muted hover:text-text-secondary'
+                }`}
+              >
+                {tab.label}
+              </RadixTabs.Trigger>
+            ))}
+          </RadixTabs.List>
+          <button
+            type="button"
+            className="px-3 py-1.5 text-[12px] bg-accent text-white font-medium rounded-md hover:bg-accent-hover transition-colors"
+            onClick={handleCopy}
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
         </div>
         <pre className="flex-1 overflow-auto p-4 text-[12px] text-text-primary font-mono leading-relaxed">
           {code}

--- a/src/components/McpModal/McpModal.tsx
+++ b/src/components/McpModal/McpModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import { Dialog } from '../ui/Dialog'
-import { Check, Copy, ChevronDown, ChevronRight } from 'lucide-react'
+import { Check, Copy, ChevronDown, ChevronRight, X } from 'lucide-react'
 
 interface McpModalProps {
   open: boolean
@@ -89,20 +89,23 @@ export function McpModal({ open, onOpenChange }: McpModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <div className="bg-surface-1 border border-border rounded-xl w-[480px] max-h-[80vh] overflow-hidden">
+      <div className="bg-surface-1 border border-border rounded-xl shadow-xl w-[480px] max-h-[80vh] overflow-hidden">
         {/* Header */}
-        <div className="px-5 pt-5 pb-3">
-          <h2 className="text-[14px] font-semibold text-text-primary">MCP Server</h2>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <h2 className="text-[13px] font-semibold text-text-primary">MCP Server</h2>
+          <button className="w-5 h-5 c-icon-btn hover:text-text-secondary hover:bg-surface-2/60" onClick={() => onOpenChange(false)}>
+            <X size={14} />
+          </button>
         </div>
 
         {/* Description */}
-        <p className="px-5 pb-4 text-[12px] text-text-secondary leading-relaxed">
+        <p className="px-4 pt-3 pb-3 text-[12px] text-text-secondary leading-relaxed">
           Connect AI agents to Caja's design canvas. The MCP server lets
           external tools read, create, and modify frames in real time.
         </p>
 
         {/* Client tabs */}
-        <div className="flex gap-1 px-5 pb-3">
+        <div className="flex gap-1 px-4 pb-3">
           {CLIENTS.map((c) => (
             <button
               key={c.id}
@@ -120,11 +123,11 @@ export function McpModal({ open, onOpenChange }: McpModalProps) {
 
         {/* Install button */}
         {isTauri && (
-          <div className="px-5 pb-3">
+          <div className="px-4 pb-3">
             <button
               onClick={handleInstall}
               disabled={installState !== 'idle'}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-accent text-white text-[12px] font-medium hover:bg-accent-hover transition-colors disabled:opacity-60"
+              className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-md bg-accent text-white text-[12px] font-medium hover:bg-accent-hover transition-colors disabled:opacity-60"
             >
               {installState === 'idle' && <>Add to {CLIENTS.find((c) => c.id === activeClient)!.label}</>}
               {installState === 'installed' && <><Check size={14} /> Installed</>}
@@ -135,7 +138,7 @@ export function McpModal({ open, onOpenChange }: McpModalProps) {
         )}
 
         {/* Manual setup (collapsible) */}
-        <div className="px-5 pb-5">
+        <div className="px-4 pb-4">
           <button
             type="button"
             onClick={() => setShowManual(!showManual)}

--- a/src/components/TreePanel/ComponentIOModal.tsx
+++ b/src/components/TreePanel/ComponentIOModal.tsx
@@ -4,6 +4,7 @@ import { readCjlFile, exportLibrary } from '../../lib/libraryOps'
 import type { CjlFileData } from '../../lib/libraryOps'
 import type { Component } from '../../types/component'
 import { X, Check } from 'lucide-react'
+import { Dialog } from '../ui/Dialog'
 
 interface ComponentIOModalProps {
   open: boolean
@@ -63,24 +64,22 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, mode])
 
-  if (!open) return null
-
   // ── Import mode ──
   if (mode === 'import') {
     if (importLoading) {
       return (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50">
-          <div className="bg-surface-1 border border-border rounded-lg shadow-xl w-[360px] p-6 text-center">
+        <Dialog open={open} onOpenChange={onOpenChange}>
+          <div className="bg-surface-1 border border-border rounded-xl shadow-xl w-[360px] p-6 text-center">
             <span className="text-[12px] text-text-muted">Reading .cjl file...</span>
           </div>
-        </div>
+        </Dialog>
       )
     }
 
     if (importError) {
       return (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50" onClick={() => onOpenChange(false)}>
-          <div className="bg-surface-1 border border-border rounded-lg shadow-xl w-[360px] flex flex-col" onClick={(e) => e.stopPropagation()}>
+        <Dialog open={open} onOpenChange={onOpenChange}>
+          <div className="bg-surface-1 border border-border rounded-xl shadow-xl w-[360px] flex flex-col">
             <div className="flex items-center justify-between px-4 py-3 border-b border-border">
               <h2 className="text-[13px] font-semibold text-text-primary">Import Error</h2>
               <button className="w-5 h-5 c-icon-btn hover:text-text-secondary hover:bg-surface-2/60" onClick={() => onOpenChange(false)}>
@@ -96,7 +95,7 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
               </button>
             </div>
           </div>
-        </div>
+        </Dialog>
       )
     }
 
@@ -136,12 +135,12 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
     }
 
     return (
-      <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50" onClick={() => onOpenChange(false)}>
-        <div className="bg-surface-1 border border-border rounded-lg shadow-xl w-[360px] max-h-[500px] flex flex-col" onClick={(e) => e.stopPropagation()}>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <div className="bg-surface-1 border border-border rounded-xl shadow-xl w-[360px] max-h-[500px] flex flex-col">
           <div className="flex items-center justify-between px-4 py-3 border-b border-border">
             <div>
               <h2 className="text-[13px] font-semibold text-text-primary">Import from {cjlData.name}</h2>
-              {cjlData.author && <p className="text-[10px] text-text-muted">by {cjlData.author}</p>}
+              {cjlData.author && <p className="text-[12px] text-text-muted">By {cjlData.author}</p>}
             </div>
             <button className="w-5 h-5 c-icon-btn hover:text-text-secondary hover:bg-surface-2/60" onClick={() => onOpenChange(false)}>
               <X size={14} />
@@ -174,7 +173,7 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
                     </div>
                     <span className="truncate">{item.name}</span>
                     {item.tags.length > 0 && (
-                      <span className="text-[10px] text-text-muted ml-auto shrink-0">{item.tags[0]}</span>
+                      <span className="px-1.5 py-0.5 text-[10px] leading-none font-medium rounded bg-surface-3/60 text-text-muted ml-auto shrink-0">{item.tags[0]}</span>
                     )}
                   </button>
                 ))}
@@ -187,7 +186,7 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
               Cancel
             </button>
             <button
-              className="px-3 py-1.5 rounded-md text-[12px] text-surface-0 font-medium bg-accent hover:bg-accent-hover transition-colors disabled:opacity-50"
+              className="px-3 py-1.5 rounded-md text-[12px] text-white font-medium bg-accent hover:bg-accent-hover transition-colors disabled:opacity-50"
               onClick={handleImport}
               disabled={selected.size === 0}
             >
@@ -195,7 +194,7 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
             </button>
           </div>
         </div>
-      </div>
+      </Dialog>
     )
   }
 
@@ -243,8 +242,8 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
   }
 
   return (
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50" onClick={() => onOpenChange(false)}>
-      <div className="bg-surface-1 border border-border rounded-lg shadow-xl w-[360px] max-h-[600px] flex flex-col" onClick={(e) => e.stopPropagation()}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <div className="bg-surface-1 border border-border rounded-xl shadow-xl w-[360px] max-h-[600px] flex flex-col">
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
           <h2 className="text-[13px] font-semibold text-text-primary">Export .cjl</h2>
           <button className="w-5 h-5 c-icon-btn hover:text-text-secondary hover:bg-surface-2/60" onClick={() => onOpenChange(false)}>
@@ -320,7 +319,7 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
                   </div>
                   <span className="truncate">{c.name}</span>
                   {c.tags.length > 0 && (
-                    <span className="text-[10px] text-text-muted ml-auto shrink-0">{c.tags[0]}</span>
+                    <span className="px-1.5 py-0.5 text-[10px] leading-none font-medium rounded bg-surface-3/60 text-text-muted ml-auto shrink-0">{c.tags[0]}</span>
                   )}
                 </button>
               ))}
@@ -333,7 +332,7 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
             Cancel
           </button>
           <button
-            className="px-3 py-1.5 rounded-md text-[12px] text-surface-0 font-medium bg-accent hover:bg-accent-hover transition-colors disabled:opacity-50"
+            className="px-3 py-1.5 rounded-md text-[12px] text-white font-medium bg-accent hover:bg-accent-hover transition-colors disabled:opacity-50"
             onClick={handleExport}
             disabled={!name.trim() || selected.size === 0 || exporting}
           >
@@ -341,6 +340,6 @@ export function ComponentIOModal({ open, mode, onOpenChange }: ComponentIOModalP
           </button>
         </div>
       </div>
-    </div>
+    </Dialog>
   )
 }


### PR DESCRIPTION
## Summary
- Consistent header pattern: title + X close button (tabs go in body, not header)
- Unified primary button style: `bg-accent text-white rounded-md hover:bg-accent-hover`
- Export: moved format tabs and Copy below header
- MCP: consistent padding, added X close button, kept description
- ComponentIO: author subtitle to 12px, capitalized "By", category tags as pills

## Test plan
- [ ] Open Export modal — header has title + X only, tabs + Copy below
- [ ] Open MCP modal — same header pattern, tabs in body
- [ ] Open Component Import modal — author text readable, tags show as pills
- [ ] All primary action buttons show white text on accent background

🤖 Generated with [Claude Code](https://claude.com/claude-code)