### PR TITLE
Add schema validation when opening .caja files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,31 +120,38 @@ function App() {
 
   const handleOpen = useCallback(async () => {
     if (!isTauri) return
-    const result = await openFile()
-    if (result) {
-      const { migrateToInternalRoot } = await import('./store/frameStore')
-      const data = result.data
-      if (data.pages && Array.isArray(data.pages)) {
-        // New multi-page format
-        const pages = (data.pages as Array<Record<string, unknown>>).map((p) => ({
-          id: p.id as string,
-          name: p.name as string,
-          route: p.route as string,
-          root: migrateToInternalRoot(p.root as Record<string, unknown>, p.id as string),
-          ...(p.isComponentPage ? { isComponentPage: true as const } : {}),
-        }))
-        const activePageId = (data.activePageId as string) || pages[0].id
-        useFrameStore.getState().loadFromFileMulti(pages, activePageId, result.path)
-      } else if (data.root) {
-        // Legacy single-root format
-        const root = migrateToInternalRoot(data.root as Record<string, unknown>, 'page-1')
-        useFrameStore.getState().loadFromFile(root, result.path)
+    try {
+      const result = await openFile()
+      if (result) {
+        const { migrateToInternalRoot } = await import('./store/frameStore')
+        const data = result.data
+        if (data.pages && Array.isArray(data.pages)) {
+          // New multi-page format
+          const pages = (data.pages as Array<Record<string, unknown>>).map((p) => ({
+            id: p.id as string,
+            name: p.name as string,
+            route: p.route as string,
+            root: migrateToInternalRoot(p.root as Record<string, unknown>, p.id as string),
+            ...(p.isComponentPage ? { isComponentPage: true as const } : {}),
+          }))
+          const activePageId = (data.activePageId as string) || pages[0].id
+          useFrameStore.getState().loadFromFileMulti(pages, activePageId, result.path)
+        } else if (data.root) {
+          // Legacy single-root format
+          const root = migrateToInternalRoot(data.root as Record<string, unknown>, 'page-1')
+          useFrameStore.getState().loadFromFile(root, result.path)
+        }
+        useCatalogStore.getState().loadComponents(data.components as import('./store/catalogStore').ComponentData | undefined)
+        // Restore blob URLs from local asset files after file load
+        import('./lib/assetOps').then(({ restoreAllAssets }) => {
+          restoreAllAssets(useFrameStore.getState().pages).catch((err) => console.warn('Asset restore failed:', err))
+        })
       }
-      useCatalogStore.getState().loadComponents(data.components as import('./store/catalogStore').ComponentData | undefined)
-      // Restore blob URLs from local asset files after file load
-      import('./lib/assetOps').then(({ restoreAllAssets }) => {
-        restoreAllAssets(useFrameStore.getState().pages).catch((err) => console.warn('Asset restore failed:', err))
-      })
+    } catch (err) {
+      console.error('Failed to open file:', err)
+      const msg = err instanceof Error ? err.message : 'Unknown error opening file'
+      const { message } = await import('@tauri-apps/plugin-dialog')
+      message(msg, { title: 'Open Failed', kind: 'error' })
     }
   }, [])
 

--- a/src/lib/fileOps.ts
+++ b/src/lib/fileOps.ts
@@ -34,6 +34,25 @@ export async function saveFileAs(pages: Page[], activePageId: string, components
   return path
 }
 
+/** Validate that the parsed JSON has a recognizable .caja structure */
+function validateCajaData(data: unknown): data is Record<string, unknown> {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false
+  const d = data as Record<string, unknown>
+  // Must have either pages array (new format) or root object (legacy)
+  const hasPages = Array.isArray(d.pages) && d.pages.length > 0
+  const hasRoot = d.root != null && typeof d.root === 'object'
+  if (!hasPages && !hasRoot) return false
+  // If pages exist, each must have id and root
+  if (hasPages) {
+    for (const page of d.pages as unknown[]) {
+      if (!page || typeof page !== 'object') return false
+      const p = page as Record<string, unknown>
+      if (typeof p.id !== 'string' || !p.root || typeof p.root !== 'object') return false
+    }
+  }
+  return true
+}
+
 export async function openFile(): Promise<{ path: string; data: Record<string, unknown> } | null> {
   const path = await open({
     filters: [FILE_FILTER],
@@ -42,6 +61,14 @@ export async function openFile(): Promise<{ path: string; data: Record<string, u
   })
   if (!path) return null
   const content = await readTextFile(path)
-  const data = JSON.parse(content)
+  let data: unknown
+  try {
+    data = JSON.parse(content)
+  } catch {
+    throw new Error('File is not valid JSON')
+  }
+  if (!validateCajaData(data)) {
+    throw new Error('File is not a valid .caja file (missing pages or root)')
+  }
   return { path, data }
 }


### PR DESCRIPTION
## Summary
- Validates JSON structure before processing (pages with id+root, or legacy root)
- Shows native error dialog on invalid/corrupted files instead of silent crash
- Wraps file open handler in try-catch

## Test plan
- [ ] Open a valid .caja file → works as before
- [ ] Open a random JSON file → shows "not a valid .caja file" error dialog
- [ ] Open a corrupted/empty file → shows "not valid JSON" error dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)