### PR TITLE
Add auth token to MCP HTTP bridge

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "uuid",
  "window-vibrancy 0.5.3",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-window-state = "2"
 tauri-plugin-http = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ struct BridgeState {
     app: AppHandle,
     pending: Arc<Mutex<HashMap<String, oneshot::Sender<String>>>>,
     next_id: Arc<Mutex<u64>>,
+    auth_token: String,
 }
 
 #[derive(Deserialize)]
@@ -54,12 +55,32 @@ struct ResourceReadEvent {
     uri: String,
 }
 
+// ── Auth helper ──
+
+fn check_auth(headers: &axum::http::HeaderMap, token: &str) -> Result<(), Json<ToolCallResponse>> {
+    let auth = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+    match auth {
+        Some(v) if v == format!("Bearer {}", token) => Ok(()),
+        _ => Err(Json(ToolCallResponse {
+            success: false,
+            data: None,
+            error: Some("Unauthorized".into()),
+        })),
+    }
+}
+
 // ── HTTP Handlers ──
 
 async fn handle_tool_call(
     State(state): State<BridgeState>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<ToolCallRequest>,
 ) -> Json<ToolCallResponse> {
+    if let Err(resp) = check_auth(&headers, &state.auth_token) {
+        return resp;
+    }
     let id = {
         let mut counter = state.next_id.lock().await;
         *counter += 1;
@@ -118,8 +139,16 @@ async fn handle_tool_call(
 
 async fn handle_resource(
     State(state): State<BridgeState>,
+    headers: axum::http::HeaderMap,
     axum::extract::Query(query): axum::extract::Query<ResourceQuery>,
 ) -> Json<serde_json::Value> {
+    let auth = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+    match auth {
+        Some(v) if v == format!("Bearer {}", state.auth_token) => {}
+        _ => return Json(serde_json::json!({"error": "Unauthorized"})),
+    }
     let id = {
         let mut counter = state.next_id.lock().await;
         *counter += 1;
@@ -515,10 +544,20 @@ pub fn run() {
             }
 
             // ── MCP HTTP Bridge ──
+            let auth_token = uuid::Uuid::new_v4().to_string();
+
+            // Write token to ~/.caja/mcp-token for server.mjs to read
+            if let Some(home) = std::env::var_os("HOME") {
+                let caja_dir = std::path::Path::new(&home).join(".caja");
+                let _ = std::fs::create_dir_all(&caja_dir);
+                let _ = std::fs::write(caja_dir.join("mcp-token"), &auth_token);
+            }
+
             let bridge_state = BridgeState {
                 app: app.handle().clone(),
                 pending: Arc::new(Mutex::new(HashMap::new())),
                 next_id: Arc::new(Mutex::new(0)),
+                auth_token,
             };
 
             // Store bridge state in Tauri's managed state

--- a/src/mcp/server.mjs
+++ b/src/mcp/server.mjs
@@ -16,23 +16,56 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
 
 const CAJA_API = process.env.CAJA_API_URL || 'http://127.0.0.1:3334'
+
+// Read auth token from ~/.caja/mcp-token (written by Caja on startup)
+function loadAuthToken() {
+  try {
+    return readFileSync(join(homedir(), '.caja', 'mcp-token'), 'utf-8').trim()
+  } catch {
+    return null
+  }
+}
+
+let authToken = loadAuthToken()
+
+function authHeaders() {
+  const headers = { 'Content-Type': 'application/json' }
+  if (authToken) headers['Authorization'] = `Bearer ${authToken}`
+  return headers
+}
 
 // ── HTTP helpers ──
 
 async function callTool(name, params) {
   const res = await fetch(`${CAJA_API}/api/tool`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: authHeaders(),
     body: JSON.stringify({ name, params }),
   })
+  if (res.status === 401) {
+    // Token may have rotated (Caja restarted), try re-reading
+    authToken = loadAuthToken()
+    const retry = await fetch(`${CAJA_API}/api/tool`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ name, params }),
+    })
+    if (!retry.ok) throw new Error(`Caja API error: ${retry.status}`)
+    return retry.json()
+  }
   if (!res.ok) throw new Error(`Caja API error: ${res.status}`)
   return res.json()
 }
 
 async function readResource(uri) {
-  const res = await fetch(`${CAJA_API}/api/resource?uri=${encodeURIComponent(uri)}`)
+  const res = await fetch(`${CAJA_API}/api/resource?uri=${encodeURIComponent(uri)}`, {
+    headers: authHeaders(),
+  })
   if (!res.ok) throw new Error(`Caja API error: ${res.status}`)
   return res.json()
 }


### PR DESCRIPTION
## Summary
- Generates UUID auth token on startup, writes to `~/.caja/mcp-token`
- `/api/tool` and `/api/resource` require `Authorization: Bearer <token>`
- `/api/health` remains open (for connection probing)
- `server.mjs` auto-reads token, retries on 401 (handles Caja restart)

## Test plan
- [ ] Start Caja → `~/.caja/mcp-token` file created with UUID
- [ ] MCP tools work via Claude Code (token auto-loaded)
- [ ] `curl localhost:3334/api/tool` without token → 401
- [ ] Restart Caja → new token → server.mjs auto-retries with new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)