### PR TITLE
Fix blob URL memory leak in asset cache

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -195,6 +195,7 @@ function App() {
         switch (e.payload) {
           case 'new':
             useFrameStore.getState().newFile()
+            import('./lib/assetOps').then(({ revokeAllBlobUrls }) => revokeAllBlobUrls())
             break
           case 'open':
             handleOpen()

--- a/src/lib/assetOps.ts
+++ b/src/lib/assetOps.ts
@@ -75,10 +75,24 @@ export function getAssetSnapshot() {
   return assetVersion
 }
 
-/** Create a blob URL from a Uint8Array */
-function createBlobUrl(data: Uint8Array, ext: string): string {
+/** Create a blob URL from a Uint8Array, revoking any previous blob for the same key */
+function createBlobUrl(data: Uint8Array, ext: string, cacheKey?: string): string {
+  // Revoke previous blob URL for this key to prevent memory leak
+  if (cacheKey) {
+    const prev = blobCache.get(cacheKey)
+    if (prev) URL.revokeObjectURL(prev)
+  }
   const blob = new Blob([data], { type: mimeFromExt(ext) })
   return URL.createObjectURL(blob)
+}
+
+/** Revoke all cached blob URLs (e.g. on File > New) */
+export function revokeAllBlobUrls(): void {
+  for (const url of blobCache.values()) {
+    URL.revokeObjectURL(url)
+  }
+  blobCache.clear()
+  bumpAssetVersion()
 }
 
 // --- Public API ---
@@ -147,7 +161,7 @@ export async function downloadAsset(url: string, projectPath: string | null): Pr
   // Create blob URL for canvas (reuse cached if available)
   let assetUrl = blobCache.get(localPath)
   if (!assetUrl) {
-    assetUrl = createBlobUrl(data, ext)
+    assetUrl = createBlobUrl(data, ext, localPath)
     blobCache.set(localPath, assetUrl)
     bumpAssetVersion()
   }
@@ -168,7 +182,7 @@ export async function restoreAssetUrl(localPath: string): Promise<string | null>
     if (!(await exists(localPath))) return null
     const data = await readFile(localPath)
     const ext = localPath.split('.').pop() || 'png'
-    const blobUrl = createBlobUrl(data, ext)
+    const blobUrl = createBlobUrl(data, ext, localPath)
     blobCache.set(localPath, blobUrl)
     bumpAssetVersion()
     return blobUrl


### PR DESCRIPTION
## Summary
- Revoke previous blob URL when replacing a cache entry (prevents duplicates)
- New `revokeAllBlobUrls()` cleans up all cached blob URLs
- Called on File > New to free memory from previous project

## Test plan
- [ ] Add images, File > New → blob URLs released (check DevTools memory)
- [ ] Load project with images → images render correctly (cache still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)