### PR TITLE
Replace screenshot timing heuristic with double rAF

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -325,8 +325,8 @@ const handlers: Record<string, ToolHandler> = {
     store.select(null)
     store.hover(null)
 
-    // Wait for React re-render + layout reflow
-    await new Promise((r) => requestAnimationFrame(() => setTimeout(r, 100)))
+    // Wait for React re-render + layout reflow (double rAF ensures paint completion)
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
 
     const fullWidth = el.scrollWidth
     const fullHeight = el.scrollHeight


### PR DESCRIPTION
## Summary
- Replace `requestAnimationFrame(() => setTimeout(r, 100))` with double `requestAnimationFrame`
- Double rAF guarantees paint completion, no arbitrary timeout needed

## Test plan
- [ ] MCP screenshot tool returns correct canvas image
- [ ] No blank/incomplete screenshots on slow machines

🤖 Generated with [Claude Code](https://claude.com/claude-code)